### PR TITLE
feat: add DeepSeek provider support

### DIFF
--- a/src/cli/onboard.rs
+++ b/src/cli/onboard.rs
@@ -4,11 +4,11 @@ use crate::{
     BabataResult,
     channel::{Channel, TelegramChannel},
     config::{
-        AgentConfig, ChannelConfig, Config, MoonshotProviderConfig, OpenAIProviderConfig,
-        ProviderConfig, TelegramChannelConfig,
+        AgentConfig, ChannelConfig, Config, DeepSeekProviderConfig, MoonshotProviderConfig,
+        OpenAIProviderConfig, ProviderConfig, TelegramChannelConfig,
     },
     error::BabataError,
-    provider::{MoonshotProvider, OpenAIProvider, Provider},
+    provider::{DeepSeekProvider, MoonshotProvider, OpenAIProvider, Provider},
 };
 
 use super::Args;
@@ -168,6 +168,7 @@ fn available_provider_names() -> Vec<String> {
     vec![
         OpenAIProvider::name().to_string(),
         MoonshotProvider::name().to_string(),
+        DeepSeekProvider::name().to_string(),
     ]
 }
 
@@ -249,6 +250,7 @@ fn supported_models_for_provider(provider_config: &ProviderConfig) -> &'static [
     match provider_config {
         ProviderConfig::OpenAI(_) => OpenAIProvider::supported_models(),
         ProviderConfig::Moonshot(_) => MoonshotProvider::supported_models(),
+        ProviderConfig::DeepSeek(_) => DeepSeekProvider::supported_models(),
     }
 }
 
@@ -263,6 +265,12 @@ fn build_provider_config(provider_name: &str, api_key: String) -> BabataResult<P
         || provider_name.eq_ignore_ascii_case("moonshot")
     {
         return Ok(ProviderConfig::Moonshot(MoonshotProviderConfig { api_key }));
+    }
+
+    if provider_name.eq_ignore_ascii_case(DeepSeekProvider::name())
+        || provider_name.eq_ignore_ascii_case("deepseek")
+    {
+        return Ok(ProviderConfig::DeepSeek(DeepSeekProviderConfig { api_key }));
     }
 
     Err(BabataError::config(format!(

--- a/src/config/provider.rs
+++ b/src/config/provider.rs
@@ -9,6 +9,8 @@ pub enum ProviderConfig {
     OpenAI(OpenAIProviderConfig),
     #[serde(rename = "moonshot")]
     Moonshot(MoonshotProviderConfig),
+    #[serde(rename = "deepseek")]
+    DeepSeek(DeepSeekProviderConfig),
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -18,6 +20,11 @@ pub struct OpenAIProviderConfig {
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct MoonshotProviderConfig {
+    pub api_key: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct DeepSeekProviderConfig {
     pub api_key: String,
 }
 
@@ -36,6 +43,7 @@ impl ProviderConfig {
         match self {
             ProviderConfig::OpenAI(config) => &config.api_key,
             ProviderConfig::Moonshot(config) => &config.api_key,
+            ProviderConfig::DeepSeek(config) => &config.api_key,
         }
     }
 
@@ -43,6 +51,7 @@ impl ProviderConfig {
         match self {
             ProviderConfig::OpenAI(_) => "openai",
             ProviderConfig::Moonshot(_) => "moonshot",
+            ProviderConfig::DeepSeek(_) => "deepseek",
         }
     }
 

--- a/src/provider/deepseek.rs
+++ b/src/provider/deepseek.rs
@@ -1,0 +1,42 @@
+use crate::{
+    BabataResult,
+    provider::{
+        GenerationReqest, GenerationResponse, InteractionRequest, InteractionResponse, Provider,
+    },
+};
+
+use super::OpenAIProvider;
+
+#[derive(Debug)]
+pub struct DeepSeekProvider {
+    inner: OpenAIProvider,
+}
+
+impl DeepSeekProvider {
+    pub fn new(api_key: &str) -> Self {
+        let inner = OpenAIProvider::new(api_key).with_base_url("https://api.deepseek.com/v1");
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for DeepSeekProvider {
+    fn name() -> &'static str {
+        "deepseek"
+    }
+
+    fn supported_models() -> &'static [&'static str] {
+        &["deepseek-chat", "deepseek-reasoner"]
+    }
+
+    async fn generate<'a>(
+        &self,
+        request: GenerationReqest<'a>,
+    ) -> BabataResult<GenerationResponse> {
+        self.inner.generate(request).await
+    }
+
+    async fn interact(&self, request: InteractionRequest) -> BabataResult<InteractionResponse> {
+        self.inner.interact(request).await
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,6 +1,8 @@
+mod deepseek;
 mod moonshot;
 mod openai;
 
+pub use deepseek::*;
 pub use moonshot::*;
 pub use openai::*;
 
@@ -51,6 +53,7 @@ pub fn create_provider(
     match provider_config {
         ProviderConfig::OpenAI(config) => Ok(Arc::new(OpenAIProvider::new(&config.api_key))),
         ProviderConfig::Moonshot(config) => Ok(Arc::new(MoonshotProvider::new(&config.api_key))),
+        ProviderConfig::DeepSeek(config) => Ok(Arc::new(DeepSeekProvider::new(&config.api_key))),
     }
 }
 


### PR DESCRIPTION
- Add DeepSeekProvider with API endpoint https://api.deepseek.com/v1
- Support models: deepseek-chat, deepseek-reasoner
- Add DeepSeekProviderConfig to config module
- Update onboard CLI to include DeepSeek in provider selection