### PR TITLE
provider: add configurable custom openai/anthropic-compatible backend

### DIFF
--- a/src/cli/onboard.rs
+++ b/src/cli/onboard.rs
@@ -4,14 +4,14 @@ use crate::{
     BabataResult,
     channel::{Channel, TelegramChannel},
     config::{
-        AgentConfig, AnthropicProviderConfig, ChannelConfig, Config, DeepSeekProviderConfig,
-        KimiProviderConfig, MoonshotProviderConfig, OpenAIProviderConfig, ProviderConfig,
-        TelegramChannelConfig,
+        AgentConfig, AnthropicProviderConfig, ChannelConfig, CompatibleApi, Config,
+        CustomProviderConfig, DeepSeekProviderConfig, KimiProviderConfig, MoonshotProviderConfig,
+        OpenAIProviderConfig, ProviderConfig, TelegramChannelConfig,
     },
     error::BabataError,
     provider::{
-        AnthropicProvider, DeepSeekProvider, KimiProvider, Model, MoonshotProvider, OpenAIProvider,
-        Provider,
+        AnthropicProvider, CustomProvider, DeepSeekProvider, KimiProvider, Model, MoonshotProvider,
+        OpenAIProvider, Provider,
     },
 };
 
@@ -222,6 +222,17 @@ fn prompt_provider_setup() -> BabataResult<Option<ProviderConfig>> {
         return Err(BabataError::config("Invalid provider selection"));
     };
 
+    if provider_name.eq_ignore_ascii_case(CustomProvider::name()) {
+        let compatible_api = prompt_custom_compatible_api()?;
+        let base_url = prompt_line("Base URL")?;
+        let api_key = prompt_line("API key")?;
+        return Ok(Some(ProviderConfig::Custom(CustomProviderConfig {
+            api_key,
+            base_url,
+            compatible_api,
+        })));
+    }
+
     let api_key = prompt_line("API key")?;
     Ok(Some(build_provider_config(provider_name, api_key)?))
 }
@@ -233,7 +244,23 @@ fn available_provider_names() -> Vec<String> {
         MoonshotProvider::name().to_string(),
         DeepSeekProvider::name().to_string(),
         AnthropicProvider::name().to_string(),
+        CustomProvider::name().to_string(),
     ]
+}
+
+fn prompt_custom_compatible_api() -> BabataResult<CompatibleApi> {
+    let value = prompt_line("Compatible API (openai/anthropic)")?;
+    if value.eq_ignore_ascii_case("openai") {
+        return Ok(CompatibleApi::Openai);
+    }
+
+    if value.eq_ignore_ascii_case("anthropic") {
+        return Ok(CompatibleApi::Anthropic);
+    }
+
+    Err(BabataError::config(
+        "Invalid compatible API, expected 'openai' or 'anthropic'",
+    ))
 }
 
 fn prompt_main_agent_setup(config: &Config) -> BabataResult<Option<AgentConfig>> {
@@ -287,7 +314,11 @@ fn prompt_main_agent_setup(config: &Config) -> BabataResult<Option<AgentConfig>>
 fn prompt_model_setup(provider_config: &ProviderConfig) -> BabataResult<String> {
     let supported_models = supported_models_for_provider(provider_config);
     if supported_models.is_empty() {
-        return Err(BabataError::config("Provider has no supported models"));
+        let model = prompt_line("Model name (free form)")?;
+        if model.trim().is_empty() {
+            return Err(BabataError::config("Model name cannot be empty"));
+        }
+        return Ok(model);
     }
 
     println!("Select model for main agent:");
@@ -319,6 +350,7 @@ fn supported_models_for_provider(provider_config: &ProviderConfig) -> &'static [
         ProviderConfig::Moonshot(_) => MoonshotProvider::supported_models(),
         ProviderConfig::DeepSeek(_) => DeepSeekProvider::supported_models(),
         ProviderConfig::Anthropic(_) => AnthropicProvider::supported_models(),
+        ProviderConfig::Custom(_) => CustomProvider::supported_models(),
     }
 }
 

--- a/src/config/provider.rs
+++ b/src/config/provider.rs
@@ -15,6 +15,8 @@ pub enum ProviderConfig {
     DeepSeek(DeepSeekProviderConfig),
     #[serde(rename = "anthropic")]
     Anthropic(AnthropicProviderConfig),
+    #[serde(rename = "custom")]
+    Custom(CustomProviderConfig),
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -42,6 +44,20 @@ pub struct AnthropicProviderConfig {
     pub api_key: String,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct CustomProviderConfig {
+    pub api_key: String,
+    pub base_url: String,
+    pub compatible_api: CompatibleApi,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CompatibleApi {
+    Openai,
+    Anthropic,
+}
+
 impl ProviderConfig {
     pub fn validate(&self) -> BabataResult<()> {
         let api_key = self.api_key().trim();
@@ -50,6 +66,16 @@ impl ProviderConfig {
                 "Provider api_key cannot be empty or whitespace",
             ));
         }
+
+        if let ProviderConfig::Custom(config) = self {
+            let base_url = config.base_url.trim();
+            if base_url.is_empty() {
+                return Err(BabataError::config(
+                    "Custom provider base_url cannot be empty or whitespace",
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -60,6 +86,7 @@ impl ProviderConfig {
             ProviderConfig::Moonshot(config) => &config.api_key,
             ProviderConfig::DeepSeek(config) => &config.api_key,
             ProviderConfig::Anthropic(config) => &config.api_key,
+            ProviderConfig::Custom(config) => &config.api_key,
         }
     }
 
@@ -70,10 +97,50 @@ impl ProviderConfig {
             ProviderConfig::Moonshot(_) => "moonshot",
             ProviderConfig::DeepSeek(_) => "deepseek",
             ProviderConfig::Anthropic(_) => "anthropic",
+            ProviderConfig::Custom(_) => "custom",
         }
     }
 
     pub fn matches_name(&self, name: &str) -> bool {
         self.provider_name().eq_ignore_ascii_case(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_custom_provider_rejects_empty_base_url() {
+        let config = ProviderConfig::Custom(CustomProviderConfig {
+            api_key: "test-key".to_string(),
+            base_url: "   ".to_string(),
+            compatible_api: CompatibleApi::Openai,
+        });
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.expect_err("expected base_url validation error");
+        assert!(err.to_string().contains("base_url"));
+    }
+
+    #[test]
+    fn parse_custom_provider_config_from_json() {
+        let payload = r#"{
+            "name": "custom",
+            "api_key": "test-key",
+            "base_url": "https://example.com/v1",
+            "compatible_api": "openai"
+        }"#;
+        let parsed: ProviderConfig = serde_json::from_str(payload).expect("parse provider json");
+
+        match parsed {
+            ProviderConfig::Custom(config) => {
+                assert_eq!(config.api_key, "test-key");
+                assert_eq!(config.base_url, "https://example.com/v1");
+                assert_eq!(config.compatible_api, CompatibleApi::Openai);
+            }
+            _ => panic!("expected ProviderConfig::Custom"),
+        }
     }
 }

--- a/src/provider/custom.rs
+++ b/src/provider/custom.rs
@@ -1,0 +1,65 @@
+use crate::{
+    BabataResult,
+    config::{CompatibleApi, CustomProviderConfig},
+    provider::{
+        AnthropicCompatibleProvider, GenerationReqest, GenerationResponse, InteractionRequest,
+        InteractionResponse, Model, OpenAICompatibleProvider, Provider,
+    },
+};
+
+#[derive(Debug)]
+enum CustomProviderInner {
+    OpenAI(OpenAICompatibleProvider),
+    Anthropic(AnthropicCompatibleProvider),
+}
+
+#[derive(Debug)]
+pub struct CustomProvider {
+    inner: CustomProviderInner,
+}
+
+const CUSTOM_SUPPORTED_MODELS: &[Model] = &[];
+
+impl CustomProvider {
+    pub fn new(config: &CustomProviderConfig) -> Self {
+        let inner = match config.compatible_api {
+            CompatibleApi::Openai => CustomProviderInner::OpenAI(
+                OpenAICompatibleProvider::new(&config.api_key, &config.base_url)
+                    .with_user_agent(None),
+            ),
+            CompatibleApi::Anthropic => CustomProviderInner::Anthropic(
+                AnthropicCompatibleProvider::new(&config.api_key, &config.base_url),
+            ),
+        };
+
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for CustomProvider {
+    fn name() -> &'static str {
+        "custom"
+    }
+
+    fn supported_models() -> &'static [Model] {
+        CUSTOM_SUPPORTED_MODELS
+    }
+
+    async fn generate<'a>(
+        &self,
+        request: GenerationReqest<'a>,
+    ) -> BabataResult<GenerationResponse> {
+        match &self.inner {
+            CustomProviderInner::OpenAI(provider) => provider.generate(request).await,
+            CustomProviderInner::Anthropic(provider) => provider.generate(request).await,
+        }
+    }
+
+    async fn interact(&self, request: InteractionRequest) -> BabataResult<InteractionResponse> {
+        match &self.inner {
+            CustomProviderInner::OpenAI(provider) => provider.interact(request).await,
+            CustomProviderInner::Anthropic(provider) => provider.interact(request).await,
+        }
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,5 +1,6 @@
 mod anthropic;
 mod anthropic_compatible;
+mod custom;
 mod deepseek;
 mod kimi;
 mod moonshot;
@@ -8,6 +9,7 @@ mod openai_compatible;
 
 pub use anthropic::*;
 pub(crate) use anthropic_compatible::*;
+pub use custom::*;
 pub use deepseek::*;
 pub use kimi::*;
 pub use moonshot::*;
@@ -68,6 +70,7 @@ pub fn create_provider(provider_config: &ProviderConfig) -> BabataResult<Arc<dyn
         ProviderConfig::Moonshot(config) => Ok(Arc::new(MoonshotProvider::new(&config.api_key))),
         ProviderConfig::DeepSeek(config) => Ok(Arc::new(DeepSeekProvider::new(&config.api_key))),
         ProviderConfig::Anthropic(config) => Ok(Arc::new(AnthropicProvider::new(&config.api_key))),
+        ProviderConfig::Custom(config) => Ok(Arc::new(CustomProvider::new(config))),
     }
 }
 


### PR DESCRIPTION
## Summary
- add a new custom provider config with ase_url, pi_key, and compatible_api (openai or nthropic)
- add CustomProvider runtime routing to OpenAI-compatible or Anthropic-compatible backends
- wire custom provider into provider factory and onboarding flow
- allow free-form model input for providers without a predefined model list (used by custom provider)
- add validation/tests for custom provider config parsing and base_url checks

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-features -- -D warnings
- cargo test parse_custom_provider_config_from_json
- cargo test validate_custom_provider_rejects_empty_base_url