### PR TITLE
Fix clippy warning: remove legacy numeric constant import

### DIFF
--- a/src/task/manager.rs
+++ b/src/task/manager.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, usize};
+use std::{collections::HashMap, sync::Arc};
 
 use chrono::Utc;
 use log::{error, info, warn};


### PR DESCRIPTION
This PR fixes a clippy warning by removing the unnecessary \+usize+ import from the legacy numeric constants.

**Changes:**
- Removed \+usize+ from imports in \+src/task/manager.rs+
- The \+usize::MAX+ constant works without explicit import in modern Rust

**Before:**
`ust
use std::{collections::HashMap, sync::Arc, usize};
`

**After:**
`ust
use std::{collections::HashMap, sync::Arc};
`

Clippy now passes without warnings.