### PR TITLE
Preserve task directories on cancel and completion

### DIFF
--- a/src/task/manager.rs
+++ b/src/task/manager.rs
@@ -232,9 +232,6 @@ impl TaskManager {
         }
 
         self.cancel_task_recursive(task_id)?;
-        if task.task_id == task.root_task_id {
-            self.remove_task_dir_recursive(task_id);
-        }
         Ok(())
     }
 
@@ -370,10 +367,6 @@ impl TaskManager {
                 "Failed to update status to done for task {}: {}",
                 task_id, err
             );
-            return;
-        }
-        if task.task_id == task.root_task_id {
-            self.remove_task_dir_recursive(task_id);
         }
     }
 
@@ -428,26 +421,6 @@ impl TaskManager {
             }
         }
     }
-
-    fn remove_task_dir_recursive(&self, task_id: Uuid) {
-        let subtasks = match self.store.list_subtasks(task_id) {
-            Ok(subtasks) => subtasks,
-            Err(err) => {
-                error!(
-                    "Failed to load subtasks for task {} while cleaning task tree directories: {}",
-                    task_id, err
-                );
-                return;
-            }
-        };
-
-        for subtask in subtasks {
-            self.remove_task_dir_recursive(subtask.task_id);
-        }
-
-        remove_task_dir(task_id);
-    }
-
     fn has_unfinished_subtasks(&self, task_id: Uuid) -> bool {
         match self.store.list_subtasks(task_id) {
             Ok(subtasks) => subtasks
@@ -733,7 +706,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_task_completed_marks_root_task_done_and_cleans_directory() {
+    async fn handle_task_completed_marks_root_task_done() {
         let temp_root = temp_test_root("manager-complete-root");
         fs::create_dir_all(&temp_root).expect("create temp root");
         let manager = build_test_manager(&temp_root);
@@ -754,7 +727,7 @@ mod tests {
 
         let stored_task = manager.store.get_task(task.task_id).expect("load task");
         assert_eq!(stored_task.status, TaskStatus::Done);
-        assert!(!task_dir(task.task_id).expect("resolve task dir").exists());
+        assert!(task_dir(task.task_id).expect("resolve task dir").exists());
 
         let _ = fs::remove_dir_all(&temp_root);
     }


### PR DESCRIPTION
This PR removes the automatic deletion of task directories when tasks are canceled or completed.

## Changes

- **cancel_task**: No longer deletes task directories when canceling a root task
- **handle_task_completed**: No longer deletes task directories when a root task completes
- **remove_task_dir_recursive**: Removed unused method
- **Tests**: Updated to verify directories are preserved after task completion

## Behavior

Task directories are now preserved in all cases except when explicitly calling 
delete_task API, which will still remove both metadata and directories.

This allows users to retain task history, logs, and files after task completion or cancellation.