### PR TITLE
Remove subpath parameter and recursively list all task files

### DIFF
--- a/src/http/list_task_files.rs
+++ b/src/http/list_task_files.rs
@@ -1,20 +1,12 @@
 use axum::{
     Json,
-    extract::{Path, Query, State},
+    extract::{Path, State},
     response::{IntoResponse, Response},
 };
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use uuid::Uuid;
 
 use super::{ApiError, HttpApp};
-
-/// Query parameters for listing task files
-#[derive(Debug, Deserialize)]
-pub(super) struct ListTaskFilesQuery {
-    /// Optional subpath within the task directory
-    #[serde(default)]
-    path: Option<String>,
-}
 
 /// File or directory entry
 #[derive(Debug, Serialize)]
@@ -36,17 +28,14 @@ pub(crate) struct FileEntry {
 pub(crate) struct ListTaskFilesResponse {
     /// Task ID
     pub(crate) task_id: String,
-    /// Current path relative to task directory
-    pub(crate) current_path: String,
-    /// Directory entries
-    pub(crate) entries: Vec<FileEntry>,
+    /// All files and directories in the task directory (recursively)
+    pub(crate) files: Vec<FileEntry>,
 }
 
 /// Handle GET /tasks/{task_id}/files
 pub(super) async fn handle(
     State(state): State<HttpApp>,
     Path(task_id): Path<String>,
-    Query(query): Query<ListTaskFilesQuery>,
 ) -> Response {
     // Parse task ID
     let task_id = match Uuid::parse_str(&task_id) {
@@ -68,33 +57,21 @@ pub(super) async fn handle(
         Err(err) => return ApiError::from_babata_error(err).into_response(),
     };
 
-    // Parse requested subpath
-    let sub_path = query.path.as_deref().unwrap_or("");
-    let target_path = task_dir.join(sub_path);
-
-    // Security check: ensure path is within task directory
-    if !is_path_within(&target_path, &task_dir) {
-        return ApiError::bad_request("Invalid path: path traversal detected".to_string())
-            .into_response();
+    // Check if task directory exists
+    if !task_dir.exists() {
+        return Json(ListTaskFilesResponse {
+            task_id: task_id.to_string(),
+            files: vec![],
+        })
+        .into_response();
     }
 
-    // Check if path exists
-    if !target_path.exists() {
-        return ApiError::bad_request(format!("Path not found: {}", sub_path)).into_response();
-    }
-
-    // Ensure it's a directory
-    if !target_path.is_dir() {
-        return ApiError::bad_request("Path is not a directory".to_string()).into_response();
-    }
-
-    // Read directory contents
-    match read_directory(&target_path, &task_dir).await {
-        Ok(entries) => {
+    // Recursively read all files
+    match read_directory_recursive(&task_dir).await {
+        Ok(files) => {
             let response = ListTaskFilesResponse {
                 task_id: task_id.to_string(),
-                current_path: sub_path.to_string(),
-                entries,
+                files,
             };
             Json(response).into_response()
         }
@@ -104,63 +81,55 @@ pub(super) async fn handle(
     }
 }
 
-/// Security check: ensure child path is within parent path
-fn is_path_within(child: &std::path::Path, parent: &std::path::Path) -> bool {
-    // Normalize paths for comparison
-    let parent_canonical = parent.canonicalize();
-    let child_canonical = child.canonicalize();
-
-    match (parent_canonical, child_canonical) {
-        (Ok(parent), Ok(child)) => child.starts_with(&parent),
-        // If canonicalization fails, reject the path
-        // This is safer than trying to resolve non-existent paths
-        _ => false,
-    }
-}
-
-/// Read directory and return file entries
-async fn read_directory(
-    dir: &std::path::Path,
+/// Recursively read directory and return all file entries using iterative approach
+async fn read_directory_recursive(
     base_dir: &std::path::Path,
 ) -> Result<Vec<FileEntry>, std::io::Error> {
     let mut entries = Vec::new();
-    let mut dir_entries = tokio::fs::read_dir(dir).await?;
+    let mut dirs_to_process: Vec<std::path::PathBuf> = vec![base_dir.to_path_buf()];
 
-    while let Some(entry) = dir_entries.next_entry().await? {
-        let metadata = entry.metadata().await?;
-        let name = entry.file_name().to_string_lossy().to_string();
+    while let Some(current_dir) = dirs_to_process.pop() {
+        let mut dir_entries = tokio::fs::read_dir(&current_dir).await?;
 
-        // Calculate relative path
-        let full_path = entry.path();
-        let rel_path = full_path
-            .strip_prefix(base_dir)
-            .unwrap_or(&full_path)
-            .to_string_lossy()
-            .to_string()
-            .replace('\\', "/");
+        while let Some(entry) = dir_entries.next_entry().await? {
+            let metadata = entry.metadata().await?;
+            let name = entry.file_name().to_string_lossy().to_string();
 
-        entries.push(FileEntry {
-            name,
-            path: rel_path,
-            is_dir: metadata.is_dir(),
-            size: if metadata.is_file() {
-                Some(metadata.len())
-            } else {
-                None
-            },
-            modified: metadata
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs()),
-        });
+            // Calculate relative path
+            let full_path = entry.path();
+            let rel_path = full_path
+                .strip_prefix(base_dir)
+                .unwrap_or(&full_path)
+                .to_string_lossy()
+                .to_string()
+                .replace('\\', "/");
+
+            let is_dir = metadata.is_dir();
+
+            entries.push(FileEntry {
+                name,
+                path: rel_path,
+                is_dir,
+                size: if is_dir { None } else { Some(metadata.len()) },
+                modified: metadata
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs()),
+            });
+
+            // Add subdirectory to processing queue
+            if is_dir {
+                dirs_to_process.push(full_path);
+            }
+        }
     }
 
-    // Sort: directories first, then files, both alphabetically
+    // Sort: directories first, then files, both alphabetically by path
     entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
         (true, false) => std::cmp::Ordering::Less,
         (false, true) => std::cmp::Ordering::Greater,
-        _ => a.name.cmp(&b.name),
+        _ => a.path.cmp(&b.path),
     });
 
     Ok(entries)
@@ -170,41 +139,28 @@ async fn read_directory(
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_is_path_within_valid() {
-        // Use std::env::current_dir() which should exist
-        let base = std::env::current_dir().unwrap();
-        let child = base.join("src").join("main.rs");
-
-        assert!(is_path_within(&child, &base));
+    #[tokio::test]
+    async fn test_read_directory_recursive() {
+        // Test with current directory's src folder
+        let base = std::env::current_dir().unwrap().join("src");
+        if base.exists() {
+            let entries = read_directory_recursive(&base).await.unwrap();
+            // Should find some files
+            assert!(!entries.is_empty());
+            // All entries should have paths starting from base
+            for entry in &entries {
+                assert!(!entry.path.starts_with('/'));
+                assert!(!entry.path.starts_with('\\'));
+            }
+        }
     }
 
-    #[test]
-    fn test_is_path_within_traversal_attack() {
-        // Use std::env::current_dir() which should exist
-        let base = std::env::current_dir().unwrap();
-        // Path traversal: going up and then to /etc/passwd
-        let child = base.join("..").join("..").join("etc").join("passwd");
-
-        assert!(!is_path_within(&child, &base));
-    }
-
-    #[test]
-    fn test_is_path_within_different_branch() {
-        // Use std::env::current_dir() which should exist
-        let base = std::env::current_dir().unwrap();
-        let base_parent = base.parent().unwrap();
-        let child = base_parent.join("other-project").join("file.txt");
-
-        assert!(!is_path_within(&child, &base));
-    }
-
-    #[test]
-    fn test_is_path_within_nonexistent_parent() {
-        let base = std::path::Path::new("/nonexistent/path/to/task-123");
-        let child = base.join("file.txt");
-
-        // Should return false when parent doesn't exist
-        assert!(!is_path_within(&child, base));
+    #[tokio::test]
+    async fn test_read_directory_recursive_empty() {
+        // Test with a non-existent directory
+        let base = std::path::PathBuf::from("/nonexistent/path/xyz123");
+        let result = read_directory_recursive(&base).await;
+        // Should return an error for non-existent directory
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Removes 'path' query parameter from GET /tasks/{task_id}/files endpoint. Now recursively traverses the entire task directory and returns all files in a flat list with relative paths. Response format updated: removed 'current_path', renamed 'entries' to 'files'. All 120 tests pass.