### PR TITLE
feat: add task_id field to all Message enum variants

### DIFF
--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -18,36 +18,6 @@ use crate::{
     tool::{Tool, ToolContext, ToolSpec},
 };
 
-fn add_task_id_to_message(message: Message, task_id: Uuid) -> Message {
-    match message {
-        Message::UserPrompt { content, .. } => Message::UserPrompt { task_id, content },
-        Message::UserSteering { content, .. } => Message::UserSteering { task_id, content },
-        Message::AssistantResponse {
-            content,
-            reasoning_content,
-            ..
-        } => Message::AssistantResponse {
-            task_id,
-            content,
-            reasoning_content,
-        },
-        Message::AssistantToolCalls {
-            calls,
-            reasoning_content,
-            ..
-        } => Message::AssistantToolCalls {
-            task_id,
-            calls,
-            reasoning_content,
-        },
-        Message::ToolResult { call, result, .. } => Message::ToolResult {
-            task_id,
-            call,
-            result,
-        },
-    }
-}
-
 const PROVIDER_RETRY_MAX_TIMES: usize = 3;
 const PROVIDER_RETRY_MIN_DELAY_MS: u64 = 200;
 const PROVIDER_RETRY_MAX_DELAY_SECS: u64 = 2;
@@ -80,7 +50,6 @@ impl AgentTask {
 
         let context = self.memory.build_context(&self.prompt).await?;
         let mut conversation = vec![Message::UserPrompt {
-            task_id: self.task_id,
             content: self.prompt.clone(),
         }];
 
@@ -98,7 +67,6 @@ impl AgentTask {
             )
             .await?;
             info!("Provider returned message: {:?}", message);
-            let message = add_task_id_to_message(message, self.task_id);
             conversation.push(message.clone());
 
             match message {
@@ -135,11 +103,7 @@ impl AgentTask {
                                 format!("Unknown tool: {}", call.tool_name)
                             };
 
-                            Message::ToolResult {
-                                task_id: self.task_id,
-                                call,
-                                result,
-                            }
+                            Message::ToolResult { call, result }
                         }
                     });
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -214,7 +214,6 @@ mod tests {
     #[test]
     fn message_json_has_type_tag() {
         let message = Message::UserPrompt {
-            task_id: Uuid::new_v4(),
             content: vec![Content::Text {
                 text: "hello".to_string(),
             }],
@@ -238,13 +237,11 @@ mod tests {
         memory
             .append_messages(&[
                 Message::UserPrompt {
-                    task_id: Uuid::new_v4(),
                     content: vec![Content::Text {
                         text: "hello".to_string(),
                     }],
                 },
                 Message::AssistantResponse {
-                    task_id: Uuid::new_v4(),
                     content: vec![Content::Text {
                         text: "world".to_string(),
                     }],

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -179,13 +179,11 @@ mod tests {
 
         let messages = vec![
             Message::UserPrompt {
-                task_id: Uuid::new_v4(),
                 content: vec![Content::Text {
                     text: "hello".to_string(),
                 }],
             },
             Message::AssistantToolCalls {
-                task_id: Uuid::new_v4(),
                 calls: vec![ToolCall {
                     call_id: "call-1".to_string(),
                     tool_name: "read_file".to_string(),
@@ -194,7 +192,6 @@ mod tests {
                 reasoning_content: None,
             },
             Message::ToolResult {
-                task_id: Uuid::new_v4(),
                 call: ToolCall {
                     call_id: "call-1".to_string(),
                     tool_name: "read_file".to_string(),
@@ -203,7 +200,6 @@ mod tests {
                 result: "file content".to_string(),
             },
             Message::AssistantResponse {
-                task_id: Uuid::new_v4(),
                 content: vec![
                     Content::Text {
                         text: "done".to_string(),
@@ -238,19 +234,16 @@ mod tests {
         let store = MessageStore::open(&db_path).expect("open sqlite message store");
         let messages = vec![
             Message::UserPrompt {
-                task_id: Uuid::new_v4(),
                 content: vec![Content::Text {
                     text: "m1".to_string(),
                 }],
             },
             Message::UserPrompt {
-                task_id: Uuid::new_v4(),
                 content: vec![Content::Text {
                     text: "m2".to_string(),
                 }],
             },
             Message::UserPrompt {
-                task_id: Uuid::new_v4(),
                 content: vec![Content::Text {
                     text: "m3".to_string(),
                 }],

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize, de::value::StringDeserializer};
-use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Role {
@@ -25,25 +24,20 @@ impl std::fmt::Display for Role {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Message {
     UserPrompt {
-        task_id: Uuid,
         content: Vec<Content>,
     },
     UserSteering {
-        task_id: Uuid,
         content: Vec<Content>,
     },
     AssistantResponse {
-        task_id: Uuid,
         content: Vec<Content>,
         reasoning_content: Option<String>,
     },
     AssistantToolCalls {
-        task_id: Uuid,
         calls: Vec<ToolCall>,
         reasoning_content: Option<String>,
     },
     ToolResult {
-        task_id: Uuid,
         call: ToolCall,
         result: String,
     },

--- a/src/provider/anthropic_compatible.rs
+++ b/src/provider/anthropic_compatible.rs
@@ -2,7 +2,6 @@ use log::{debug, warn};
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use uuid::Uuid;
 
 use crate::{
     BabataResult,
@@ -246,7 +245,6 @@ impl AnthropicCompatibleProvider {
             };
             return Ok(GenerationResponse {
                 message: Message::AssistantToolCalls {
-                    task_id: Uuid::nil(),
                     calls: tool_calls,
                     reasoning_content,
                 },
@@ -259,7 +257,6 @@ impl AnthropicCompatibleProvider {
 
         Ok(GenerationResponse {
             message: Message::AssistantResponse {
-                task_id: Uuid::nil(),
                 content: text_content,
                 reasoning_content: None,
             },

--- a/src/provider/openai_compatible.rs
+++ b/src/provider/openai_compatible.rs
@@ -2,7 +2,6 @@ use log::{debug, warn};
 use reqwest::{Client, StatusCode, header::USER_AGENT};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use uuid::Uuid;
 
 use crate::{
     BabataResult,
@@ -260,7 +259,6 @@ impl OpenAICompatibleProvider {
             if !parsed_calls.is_empty() {
                 return Ok(GenerationResponse {
                     message: Message::AssistantToolCalls {
-                        task_id: Uuid::nil(),
                         calls: parsed_calls,
                         reasoning_content: choice.message.reasoning_content,
                     },
@@ -274,7 +272,6 @@ impl OpenAICompatibleProvider {
 
         Ok(GenerationResponse {
             message: Message::AssistantResponse {
-                task_id: Uuid::nil(),
                 content: vec![Content::Text { text: content }],
                 reasoning_content: choice.message.reasoning_content,
             },
@@ -444,7 +441,6 @@ pub struct ChatCompletionsMessageToolCallFunction {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
-    use uuid::Uuid;
 
     use crate::{
         message::{Content, MediaType, Message},
@@ -480,7 +476,6 @@ mod tests {
     fn format_messages_maps_audio_data_to_input_audio() {
         let provider = OpenAICompatibleProvider::new("test-key", "https://example.com/v1");
         let messages = vec![Message::UserPrompt {
-            task_id: Uuid::nil(),
             content: vec![Content::AudioData {
                 data: "base64-audio".to_string(),
                 media_type: MediaType::AudioMp3,
@@ -508,7 +503,6 @@ mod tests {
     fn format_messages_places_context_before_prompts() {
         let provider = OpenAICompatibleProvider::new("test-key", "https://example.com/v1");
         let prompts = vec![Message::UserPrompt {
-            task_id: Uuid::nil(),
             content: vec![Content::Text {
                 text: "latest prompt".to_string(),
             }],
@@ -530,7 +524,6 @@ mod tests {
         let provider = OpenAICompatibleProvider::new("test-key", "https://example.com/v1");
         let system_prompts = vec!["first rules".to_string(), "second rules".to_string()];
         let prompts = vec![Message::UserPrompt {
-            task_id: Uuid::nil(),
             content: vec![Content::Text {
                 text: "latest prompt".to_string(),
             }],
@@ -556,7 +549,6 @@ mod tests {
             .with_combined_system_prompt(true);
         let system_prompts = vec!["first rules".to_string(), "second rules".to_string()];
         let prompts = vec![Message::UserPrompt {
-            task_id: Uuid::nil(),
             content: vec![Content::Text {
                 text: "latest prompt".to_string(),
             }],


### PR DESCRIPTION
## Summary

Add task_id field to all message types in the Message enum:

- UserPrompt
- UserSteering  
- AssistantResponse
- AssistantToolCalls
- ToolResult

## Breaking Change

This is a breaking change without backward compatibility.

## Implementation

The runner automatically populates task_id from the current task context when creating messages.

## Testing

All 115 tests pass.