### PR TITLE
refactor: remove Windows service support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,6 @@ dependencies = [
  "teloxide",
  "tokio",
  "uuid",
- "windows-service",
 ]
 
 [[package]]
@@ -3230,12 +3229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3328,17 +3321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-service"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193cae8e647981c35bc947fdd57ba7928b1fa0d4a79305f6dd2dc55221ac35ac"
-dependencies = [
- "bitflags 2.10.0",
- "widestring",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,15 +3343,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,3 @@ teloxide = "0.13"
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.20", features = ["v4", "serde"] }
 rand = "0.8"
-
-[target.'cfg(windows)'.dependencies]
-windows-service = "0.8"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -42,15 +42,6 @@ pub enum ServerAction {
     Stop,
     #[command(about = "Restart background service on current platform")]
     Restart,
-    #[command(
-        name = "windows-service-host",
-        hide = true,
-        about = "Run Windows service host"
-    )]
-    WindowsServiceHost {
-        #[arg(long, hide = true, value_name = "HOME_DIR")]
-        home_dir: String,
-    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/cli/onboard.rs
+++ b/src/cli/onboard.rs
@@ -291,21 +291,6 @@ fn prompt_line(label: &str) -> BabataResult<String> {
 }
 
 fn configure_background_service() -> BabataResult<bool> {
-    if std::env::consts::OS == "windows" {
-        if let Err(err) = super::server::install_windows_service() {
-            if super::server::is_windows_service_permission_denied_message(&err.to_string()) {
-                println!(
-                    "Warning: Windows service was not created due to missing Administrator privileges."
-                );
-                println!("Run an elevated shell and execute: babata server start");
-                return Ok(false);
-            }
-            return Err(err);
-        }
-        println!("Configured Windows service: babata.server");
-        return Ok(true);
-    }
-
     let (template_content, template_name, output_name, output_dir) = match std::env::consts::OS {
         "macos" => (
             EMBEDDED_MACOS_SERVICE_TEMPLATE,

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -1,12 +1,6 @@
-use std::{
-    path::Path,
-    process::Command,
-    sync::Arc,
-    thread,
-    time::{Duration, Instant},
-};
+use std::{path::Path, process::Command, sync::Arc};
 
-use log::{error, info, warn};
+use log::{error, info};
 
 use crate::{
     BabataResult, agent::load_agents, config::Config, error::BabataError, http::HttpApp,
@@ -23,10 +17,6 @@ use crate::{
 
 const MACOS_LAUNCHD_LABEL: &str = "babata.server";
 const LINUX_SYSTEMD_SERVICE: &str = "babata.server.service";
-const WINDOWS_SERVICE_NAME: &str = "babata.server";
-const WINDOWS_SERVICE_DISPLAY_NAME: &str = "Babata Server";
-const WINDOWS_SERVICE_DESCRIPTION: &str =
-    "Babata background server managed by Windows Service Control Manager.";
 
 pub fn serve() {
     if let Err(err) = run_serve() {
@@ -56,40 +46,8 @@ pub fn restart() {
     }
 }
 
-pub fn windows_service_host(home_dir: &str) {
-    if let Err(err) = run_windows_service_host(home_dir) {
-        eprintln!("{err}");
-        std::process::exit(1);
-    }
-}
-
 pub fn start_background_service() -> BabataResult<()> {
     run_start()
-}
-
-pub fn install_windows_service() -> BabataResult<()> {
-    if std::env::consts::OS != "windows" {
-        return Err(BabataError::config(
-            "Windows service installation is only supported on Windows",
-        ));
-    }
-
-    let exe_path = std::env::current_exe().map_err(|err| {
-        BabataError::internal(format!("Failed to resolve current executable path: {err}"))
-    })?;
-    let home_dir = crate::utils::resolve_home_dir()?;
-    let bin_path = windows_service_bin_path(&exe_path, &home_dir);
-
-    if let Err(err) = create_or_update_windows_service(&bin_path) {
-        if is_windows_service_permission_denied_message(&err.to_string()) {
-            return Err(BabataError::config(
-                "Installing Windows service requires Administrator privileges. Re-run in an elevated shell, e.g. \"babata onboard\" or \"babata server start\" as Administrator.",
-            ));
-        }
-        return Err(err);
-    }
-    configure_windows_service_metadata();
-    Ok(())
 }
 
 fn run_serve() -> BabataResult<()> {
@@ -151,7 +109,9 @@ fn run_start() -> BabataResult<()> {
     match std::env::consts::OS {
         "macos" => start_macos(),
         "linux" => start_linux(),
-        "windows" => start_windows(),
+        "windows" => Err(BabataError::config(
+            "Windows service is not supported. Use 'babata server serve' to run in foreground.",
+        )),
         os => Err(BabataError::config(format!(
             "Server start is not supported on '{}'",
             os
@@ -163,7 +123,9 @@ fn run_stop() -> BabataResult<()> {
     match std::env::consts::OS {
         "macos" => stop_macos(),
         "linux" => stop_linux(),
-        "windows" => stop_windows(),
+        "windows" => Err(BabataError::config(
+            "Windows service is not supported. Use 'babata server serve' to run in foreground.",
+        )),
         os => Err(BabataError::config(format!(
             "Server stop is not supported on '{}'",
             os
@@ -175,7 +137,9 @@ fn run_restart() -> BabataResult<()> {
     match std::env::consts::OS {
         "macos" => restart_macos(),
         "linux" => restart_linux(),
-        "windows" => restart_windows(),
+        "windows" => Err(BabataError::config(
+            "Windows service is not supported. Use 'babata server serve' to run in foreground.",
+        )),
         os => Err(BabataError::config(format!(
             "Server restart is not supported on '{}'",
             os
@@ -261,48 +225,6 @@ fn stop_linux() -> BabataResult<()> {
     Ok(())
 }
 
-fn start_windows() -> BabataResult<()> {
-    install_windows_service()?;
-    start_windows_service()?;
-
-    println!(
-        "Started server with Windows Service: {}",
-        WINDOWS_SERVICE_NAME
-    );
-    Ok(())
-}
-
-fn restart_windows() -> BabataResult<()> {
-    install_windows_service()?;
-
-    let _ = stop_windows_service();
-    wait_for_windows_service_state(WindowsServiceState::Stopped, Duration::from_secs(30))?;
-    start_windows_service()?;
-    wait_for_windows_service_state(WindowsServiceState::Running, Duration::from_secs(30))?;
-
-    println!(
-        "Restarted server with Windows Service: {}",
-        WINDOWS_SERVICE_NAME
-    );
-    Ok(())
-}
-
-fn stop_windows() -> BabataResult<()> {
-    stop_windows_service()?;
-    stop_windows_running_processes()?;
-    println!("Stopped server on Windows");
-    Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WindowsServiceState {
-    Stopped,
-    StartPending,
-    StopPending,
-    Running,
-    Unknown,
-}
-
 fn macos_plist_path() -> BabataResult<std::path::PathBuf> {
     Ok(crate::utils::resolve_home_dir()?
         .join("Library")
@@ -314,229 +236,6 @@ fn linux_systemd_service_path() -> BabataResult<std::path::PathBuf> {
     Ok(crate::utils::babata_dir()?
         .join("services")
         .join(LINUX_SYSTEMD_SERVICE))
-}
-
-fn windows_service_bin_path(exe_path: &Path, home_dir: &Path) -> String {
-    format!(
-        "\"{}\" server windows-service-host --home-dir \"{}\"",
-        exe_path.to_string_lossy(),
-        home_dir.to_string_lossy()
-    )
-}
-
-fn wait_for_windows_service_state(
-    target: WindowsServiceState,
-    timeout: Duration,
-) -> BabataResult<()> {
-    let deadline = Instant::now() + timeout;
-    loop {
-        let state = query_windows_service_state()?;
-        if state == target {
-            return Ok(());
-        }
-
-        if Instant::now() >= deadline {
-            return Err(BabataError::internal(format!(
-                "Timed out waiting for Windows service '{}' to reach state {:?}; current state: {:?}",
-                WINDOWS_SERVICE_NAME, target, state
-            )));
-        }
-
-        thread::sleep(Duration::from_millis(500));
-    }
-}
-
-fn query_windows_service_state() -> BabataResult<WindowsServiceState> {
-    let output = Command::new("sc")
-        .args(["query", WINDOWS_SERVICE_NAME])
-        .output()
-        .map_err(|err| {
-            BabataError::internal(format!(
-                "Failed to execute command 'sc query {}': {}",
-                WINDOWS_SERVICE_NAME, err
-            ))
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let details = if stderr.is_empty() { stdout } else { stderr };
-        return Err(BabataError::internal(format!(
-            "Command 'sc query {}' failed with status {}: {}",
-            WINDOWS_SERVICE_NAME, output.status, details
-        )));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(parse_windows_service_state(&stdout))
-}
-
-fn parse_windows_service_state(sc_query_output: &str) -> WindowsServiceState {
-    let lower = sc_query_output.to_ascii_lowercase();
-    if lower.contains("stop_pending") {
-        return WindowsServiceState::StopPending;
-    }
-    if lower.contains("start_pending") {
-        return WindowsServiceState::StartPending;
-    }
-    if lower.contains("running") {
-        return WindowsServiceState::Running;
-    }
-    if lower.contains("stopped") {
-        return WindowsServiceState::Stopped;
-    }
-    WindowsServiceState::Unknown
-}
-
-fn create_or_update_windows_service(bin_path: &str) -> BabataResult<()> {
-    let create_result = run_command(
-        "sc",
-        &[
-            "create",
-            WINDOWS_SERVICE_NAME,
-            "type=",
-            "own",
-            "start=",
-            "auto",
-            "binPath=",
-            bin_path,
-            "displayname=",
-            WINDOWS_SERVICE_DISPLAY_NAME,
-        ],
-    );
-
-    if create_result.is_ok() {
-        return Ok(());
-    }
-
-    let create_err = create_result.expect_err("create_result checked is_err");
-    let err_text = create_err.to_string();
-    if !is_windows_service_already_exists_error(&err_text) {
-        return Err(create_err);
-    }
-
-    run_command(
-        "sc",
-        &[
-            "config",
-            WINDOWS_SERVICE_NAME,
-            "type=",
-            "own",
-            "start=",
-            "auto",
-            "binPath=",
-            bin_path,
-            "displayname=",
-            WINDOWS_SERVICE_DISPLAY_NAME,
-        ],
-    )
-}
-
-fn configure_windows_service_metadata() {
-    if let Err(err) = run_command(
-        "sc",
-        &[
-            "description",
-            WINDOWS_SERVICE_NAME,
-            WINDOWS_SERVICE_DESCRIPTION,
-        ],
-    ) {
-        warn!("Failed to set Windows service description: {}", err);
-    }
-
-    if let Err(err) = run_command(
-        "sc",
-        &[
-            "failure",
-            WINDOWS_SERVICE_NAME,
-            "reset=",
-            "86400",
-            "actions=",
-            "restart/5000/restart/5000/restart/5000",
-        ],
-    ) {
-        warn!("Failed to set Windows service recovery actions: {}", err);
-    }
-}
-
-fn start_windows_service() -> BabataResult<()> {
-    match run_command("sc", &["start", WINDOWS_SERVICE_NAME]) {
-        Err(err) if !is_windows_service_already_running_error(&err.to_string()) => {
-            return Err(err);
-        }
-        _ => {}
-    }
-    Ok(())
-}
-
-fn stop_windows_service() -> BabataResult<()> {
-    if let Err(err) = run_command("sc", &["stop", WINDOWS_SERVICE_NAME]) {
-        let err_text = err.to_string();
-        if !is_windows_service_not_running_error(&err_text)
-            && !is_windows_service_not_found_error(&err_text)
-        {
-            return Err(err);
-        }
-    }
-    Ok(())
-}
-
-fn stop_windows_running_processes() -> BabataResult<()> {
-    run_command(
-        "powershell.exe",
-        &[
-            "-NoProfile",
-            "-NonInteractive",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-Command",
-            "$procs = Get-CimInstance Win32_Process | Where-Object { $_.Name -ieq 'babata.exe' -and $_.CommandLine -match '(?i)\\bserver\\s+serve\\b' }; foreach ($proc in $procs) { Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue }",
-        ],
-    )
-}
-
-#[cfg(windows)]
-fn run_windows_service_host(home_dir: &str) -> BabataResult<()> {
-    windows_service_host::run(home_dir)
-}
-
-#[cfg(not(windows))]
-fn run_windows_service_host(_home_dir: &str) -> BabataResult<()> {
-    Err(BabataError::config(
-        "Windows service host can only run on Windows",
-    ))
-}
-
-fn is_windows_service_already_exists_error(message: &str) -> bool {
-    let lower = message.to_ascii_lowercase();
-    lower.contains("1073") || lower.contains("already exists")
-}
-
-fn is_windows_service_already_running_error(message: &str) -> bool {
-    let lower = message.to_ascii_lowercase();
-    lower.contains("1056") || lower.contains("already running")
-}
-
-fn is_windows_service_not_running_error(message: &str) -> bool {
-    let lower = message.to_ascii_lowercase();
-    lower.contains("1062") || lower.contains("not been started")
-}
-
-fn is_windows_service_not_found_error(message: &str) -> bool {
-    let lower = message.to_ascii_lowercase();
-    lower.contains("1060") || lower.contains("does not exist")
-}
-
-pub fn is_windows_service_permission_denied_message(message: &str) -> bool {
-    let lower = message.to_ascii_lowercase();
-    let is_service_cmd = lower.contains("command 'sc create")
-        || lower.contains("command 'sc config")
-        || lower.contains("openscmanager")
-        || lower.contains("openservice");
-    let is_access_denied = lower.contains("status exit code: 5")
-        || lower.contains("access is denied")
-        || lower.contains("failed 5");
-    is_service_cmd && is_access_denied
 }
 
 fn ensure_file_exists(path: &Path, message: &str) -> BabataResult<()> {
@@ -605,262 +304,9 @@ fn is_macos_service_not_found_error(message: &str) -> bool {
         || message.contains("No such process")
 }
 
-#[cfg(windows)]
-mod windows_service_host {
-    use std::{
-        ffi::OsString,
-        path::PathBuf,
-        process::{Child, Command},
-        sync::{OnceLock, mpsc},
-        time::Duration,
-    };
-
-    use windows_service::{
-        define_windows_service,
-        service::{
-            ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus,
-            ServiceType,
-        },
-        service_control_handler::{self, ServiceControlHandlerResult, ServiceStatusHandle},
-        service_dispatcher,
-    };
-
-    use crate::{BabataResult, error::BabataError};
-    use log::info;
-
-    static SERVICE_HOME_DIR: OnceLock<String> = OnceLock::new();
-    static SERVICE_EXE_PATH: OnceLock<PathBuf> = OnceLock::new();
-
-    define_windows_service!(ffi_service_main, service_main);
-
-    pub fn run(home_dir: &str) -> BabataResult<()> {
-        let home_dir = home_dir.trim();
-        if home_dir.is_empty() {
-            return Err(BabataError::config(
-                "Windows service host requires non-empty --home-dir",
-            ));
-        }
-        let resolved_home_dir = home_dir.to_string();
-        let _ = SERVICE_HOME_DIR.set(resolved_home_dir);
-        info!(
-            "Windows service host starting with home directory: {}",
-            home_dir
-        );
-
-        let exe_path = std::env::current_exe().map_err(|err| {
-            BabataError::internal(format!("Failed to resolve current executable path: {err}"))
-        })?;
-        let _ = SERVICE_EXE_PATH.set(exe_path);
-        info!(
-            "Windows service host resolved executable path: {}",
-            SERVICE_EXE_PATH.get().unwrap().display()
-        );
-
-        service_dispatcher::start(super::WINDOWS_SERVICE_NAME, ffi_service_main).map_err(|err| {
-            BabataError::internal(format!(
-                "Failed to start Windows service dispatcher: {}",
-                err
-            ))
-        })
-    }
-
-    fn service_main(_arguments: Vec<OsString>) {
-        if let Err(err) = run_service_main() {
-            eprintln!("{err}");
-        }
-    }
-
-    fn run_service_main() -> BabataResult<()> {
-        let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
-
-        let status_handle =
-            service_control_handler::register(super::WINDOWS_SERVICE_NAME, move |control| {
-                match control {
-                    ServiceControl::Stop | ServiceControl::Shutdown => {
-                        let _ = shutdown_tx.send(());
-                        ServiceControlHandlerResult::NoError
-                    }
-                    ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
-                    _ => ServiceControlHandlerResult::NotImplemented,
-                }
-            })
-            .map_err(|err| {
-                BabataError::internal(format!(
-                    "Failed to register Windows service control handler: {}",
-                    err
-                ))
-            })?;
-
-        set_service_status(
-            &status_handle,
-            ServiceState::StartPending,
-            ServiceControlAccept::empty(),
-            ServiceExitCode::Win32(0),
-            5,
-        )?;
-
-        let mut child = match spawn_server_child() {
-            Ok(child) => child,
-            Err(err) => {
-                let _ = set_service_status(
-                    &status_handle,
-                    ServiceState::Stopped,
-                    ServiceControlAccept::empty(),
-                    ServiceExitCode::Win32(1),
-                    0,
-                );
-                return Err(err);
-            }
-        };
-
-        set_service_status(
-            &status_handle,
-            ServiceState::Running,
-            ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
-            ServiceExitCode::Win32(0),
-            0,
-        )?;
-
-        loop {
-            if shutdown_rx.recv_timeout(Duration::from_secs(1)).is_ok() {
-                break;
-            }
-
-            if let Some(exit_status) = child.try_wait().map_err(|err| {
-                BabataError::internal(format!("Failed to monitor child process: {}", err))
-            })? {
-                let _ = set_service_status(
-                    &status_handle,
-                    ServiceState::Stopped,
-                    ServiceControlAccept::empty(),
-                    ServiceExitCode::Win32(1),
-                    0,
-                );
-                return Err(BabataError::internal(format!(
-                    "Babata server child process exited unexpectedly: {}",
-                    exit_status
-                )));
-            }
-        }
-
-        set_service_status(
-            &status_handle,
-            ServiceState::StopPending,
-            ServiceControlAccept::empty(),
-            ServiceExitCode::Win32(0),
-            10,
-        )?;
-        terminate_child(&mut child)?;
-        set_service_status(
-            &status_handle,
-            ServiceState::Stopped,
-            ServiceControlAccept::empty(),
-            ServiceExitCode::Win32(0),
-            0,
-        )?;
-        Ok(())
-    }
-
-    fn set_service_status(
-        status_handle: &ServiceStatusHandle,
-        state: ServiceState,
-        controls_accepted: ServiceControlAccept,
-        exit_code: ServiceExitCode,
-        wait_hint_secs: u64,
-    ) -> BabataResult<()> {
-        let checkpoint = match state {
-            ServiceState::StartPending | ServiceState::StopPending => 1,
-            _ => 0,
-        };
-        status_handle
-            .set_service_status(ServiceStatus {
-                service_type: ServiceType::OWN_PROCESS,
-                current_state: state,
-                controls_accepted,
-                exit_code,
-                checkpoint,
-                wait_hint: Duration::from_secs(wait_hint_secs),
-                process_id: None,
-            })
-            .map_err(|err| {
-                BabataError::internal(format!("Failed to update Windows service status: {}", err))
-            })
-    }
-
-    fn spawn_server_child() -> BabataResult<Child> {
-        let home_dir = SERVICE_HOME_DIR.get().cloned().ok_or_else(|| {
-            BabataError::internal("Windows service home directory not initialized")
-        })?;
-        let home_path = PathBuf::from(&home_dir);
-        let workdir = home_path.join(".babata");
-        std::fs::create_dir_all(&workdir).map_err(|err| {
-            BabataError::internal(format!(
-                "Failed to create working directory '{}': {}",
-                workdir.display(),
-                err
-            ))
-        })?;
-
-        let exe_path = SERVICE_EXE_PATH.get().cloned().ok_or_else(|| {
-            BabataError::internal("Windows service executable path not initialized")
-        })?;
-
-        let cargo_bin = home_path.join(".cargo").join("bin");
-        let existing_path = std::env::var("PATH").unwrap_or_default();
-        let merged_path = if existing_path.is_empty() {
-            cargo_bin.to_string_lossy().into_owned()
-        } else {
-            format!("{};{}", cargo_bin.to_string_lossy(), existing_path)
-        };
-
-        let mut child_cmd = Command::new(exe_path);
-        child_cmd
-            .arg("server")
-            .arg("serve")
-            .current_dir(&workdir)
-            .env("HOME", &home_dir)
-            .env("USERPROFILE", &home_dir)
-            .env("PATH", merged_path);
-        if let Some(username) = home_path.file_name().and_then(|name| name.to_str()) {
-            child_cmd.env("USERNAME", username);
-        }
-
-        child_cmd.spawn().map_err(|err| {
-            BabataError::internal(format!(
-                "Failed to start babata server child process: {}",
-                err
-            ))
-        })
-    }
-
-    fn terminate_child(child: &mut Child) -> BabataResult<()> {
-        if child
-            .try_wait()
-            .map_err(|err| {
-                BabataError::internal(format!(
-                    "Failed to inspect child process before termination: {}",
-                    err
-                ))
-            })?
-            .is_some()
-        {
-            return Ok(());
-        }
-
-        child.kill().map_err(|err| {
-            BabataError::internal(format!("Failed to stop child process: {}", err))
-        })?;
-        let _ = child.wait();
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        WindowsServiceState, is_macos_service_not_found_error, parse_windows_service_state,
-        windows_service_bin_path,
-    };
+    use super::is_macos_service_not_found_error;
 
     #[test]
     fn detects_launchctl_missing_service_error() {
@@ -872,44 +318,5 @@ mod tests {
     fn does_not_misclassify_unrelated_launchctl_error() {
         let message = "Internal error: Command 'launchctl kickstart -k gui/501/babata.server' failed: permission denied";
         assert!(!is_macos_service_not_found_error(message));
-    }
-
-    #[test]
-    fn builds_windows_service_bin_path_with_home_dir() {
-        let cmdline = windows_service_bin_path(
-            std::path::Path::new(r"C:\Users\alice\.cargo\bin\babata.exe"),
-            std::path::Path::new(r"C:\Users\alice"),
-        );
-        assert_eq!(
-            cmdline,
-            "\"C:\\Users\\alice\\.cargo\\bin\\babata.exe\" server windows-service-host --home-dir \"C:\\Users\\alice\""
-        );
-    }
-
-    #[test]
-    fn parses_windows_service_state_running() {
-        let output = r#"
-SERVICE_NAME: babata.server
-        TYPE               : 10  WIN32_OWN_PROCESS
-        STATE              : 4  RUNNING
-                                (STOPPABLE, NOT_PAUSABLE, ACCEPTS_SHUTDOWN)
-"#;
-        assert_eq!(
-            parse_windows_service_state(output),
-            WindowsServiceState::Running
-        );
-    }
-
-    #[test]
-    fn parses_windows_service_state_stop_pending() {
-        let output = r#"
-SERVICE_NAME: babata.server
-        TYPE               : 10  WIN32_OWN_PROCESS
-        STATE              : 3  STOP_PENDING
-"#;
-        assert_eq!(
-            parse_windows_service_state(output),
-            WindowsServiceState::StopPending
-        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,6 @@ fn main() {
             babata::cli::ServerAction::Start => babata::cli::server::start(),
             babata::cli::ServerAction::Stop => babata::cli::server::stop(),
             babata::cli::ServerAction::Restart => babata::cli::server::restart(),
-            babata::cli::ServerAction::WindowsServiceHost { home_dir } => {
-                babata::cli::server::windows_service_host(&home_dir)
-            }
         },
         babata::cli::Command::Channel { action } => match action {
             babata::cli::ChannelAction::Add {


### PR DESCRIPTION
## Summary
Remove Windows service related code from the codebase to simplify the codebase and reduce maintenance burden.

## Changes
- Remove windows-service crate dependency from Cargo.toml
- Remove WindowsServiceHost command and handling
- Remove install_windows_service(), windows_service_host() functions  
- Remove Windows service lifecycle management (start/stop/restart)
- Remove Windows service state query and SC command operations
- Remove windows_service_host module (250+ lines)
- Remove Windows service related error handling functions
- Remove Windows service unit tests
- Update run_start(), run_stop(), run_restart() to return helpful error on Windows

## Impact on Windows Users
Windows users should now use `babata server serve` to run the server in foreground.

## Verification
- ✅ cargo check passes with no warnings
- ✅ All 146 tests pass
- ✅ cargo fmt applied