### PR TITLE
refactor: deserialize create_task HTTP response to strongly typed struct

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.rs text eol=lf

--- a/src/http/create_task.rs
+++ b/src/http/create_task.rs
@@ -1,5 +1,6 @@
 use axum::{Json, extract::State};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::{
     BabataResult,
@@ -25,13 +26,13 @@ pub(super) async fn handle(
 
     let task_id = state.task_manager.create_task(request)?;
     Ok(Json(CreateTaskResponse {
-        task_id: task_id.to_string(),
-        status: TaskStatus::Running.to_string(),
+        task_id,
+        status: TaskStatus::Running,
     }))
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CreateTaskResponse {
-    task_id: String,
-    status: String,
+    pub task_id: Uuid,
+    pub status: TaskStatus,
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -25,6 +25,7 @@ use crate::{BabataResult, error::BabataError, task::TaskManager};
 pub(crate) use collaborate_task::CollaborateTaskRequest;
 pub(crate) use control_task::{ControlTaskRequest, TaskAction};
 pub(crate) use count_tasks::CountTasksResponse;
+pub(crate) use create_task::CreateTaskResponse;
 pub(crate) use get_task::TaskResponse;
 pub(crate) use steer_task::SteerTaskRequest;
 

--- a/src/tool/create_task.rs
+++ b/src/tool/create_task.rs
@@ -5,17 +5,11 @@ use serde::Deserialize;
 use crate::{
     BabataResult,
     error::BabataError,
-    http::DEFAULT_HTTP_BASE_URL,
+    http::{CreateTaskResponse, DEFAULT_HTTP_BASE_URL},
     message::Content,
     task::CreateTaskRequest,
     tool::{Tool, ToolContext, ToolSpec, parse_tool_args},
 };
-
-#[derive(Debug, Deserialize)]
-struct CreateTaskResponse {
-    task_id: String,
-    status: String,
-}
 
 #[derive(Debug)]
 pub struct CreateTaskTool {

--- a/src/tool/create_task.rs
+++ b/src/tool/create_task.rs
@@ -11,6 +11,12 @@ use crate::{
     tool::{Tool, ToolContext, ToolSpec, parse_tool_args},
 };
 
+#[derive(Debug, Deserialize)]
+struct CreateTaskResponse {
+    task_id: String,
+    status: String,
+}
+
 #[derive(Debug)]
 pub struct CreateTaskTool {
     spec: ToolSpec,
@@ -70,12 +76,20 @@ impl Tool for CreateTaskTool {
             )));
         }
 
-        response.text().await.map_err(|err| {
-            BabataError::tool(format!(
-                "Failed to read create_task HTTP API response body: {}",
-                err
-            ))
-        })
+        let response_body = response
+            .json::<CreateTaskResponse>()
+            .await
+            .map_err(|err| {
+                BabataError::tool(format!(
+                    "Failed to deserialize create_task HTTP API response: {}",
+                    err
+                ))
+            })?;
+
+        Ok(format!(
+            "Task created successfully. Task ID: {}, Status: {}",
+            response_body.task_id, response_body.status
+        ))
     }
 }
 

--- a/src/tool/create_task.rs
+++ b/src/tool/create_task.rs
@@ -76,15 +76,12 @@ impl Tool for CreateTaskTool {
             )));
         }
 
-        let response_body = response
-            .json::<CreateTaskResponse>()
-            .await
-            .map_err(|err| {
-                BabataError::tool(format!(
-                    "Failed to deserialize create_task HTTP API response: {}",
-                    err
-                ))
-            })?;
+        let response_body = response.json::<CreateTaskResponse>().await.map_err(|err| {
+            BabataError::tool(format!(
+                "Failed to deserialize create_task HTTP API response: {}",
+                err
+            ))
+        })?;
 
         Ok(format!(
             "Task created successfully. Task ID: {}, Status: {}",


### PR DESCRIPTION
## Changes
- Modified \create_task\ tool to deserialize HTTP response into strongly typed \CreateTaskResponse\ struct
- Added \CreateTaskResponse\ struct with \Deserialize\ trait
- Changed from \esponse.text()\ to \esponse.json::<CreateTaskResponse>()\
- Improved response formatting with structured data

## Benefits
- Type safety for HTTP API responses
- Better error messages on deserialization failures
- Clearer response structure