### PR TITLE
feat: add Agent CRUD API endpoints

### DIFF
--- a/src/agent/definition.rs
+++ b/src/agent/definition.rs
@@ -4,11 +4,11 @@ use std::{
     sync::Arc,
 };
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{BabataResult, error::BabataError, utils::babata_dir};
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct AgentFrontmatter {
     pub name: String,
     pub description: String,
@@ -166,4 +166,102 @@ fn parse_agent_content(content: &str, path: &Path) -> BabataResult<(AgentFrontma
     })?;
 
     Ok((headers, body))
+}
+
+/// Save an agent to AGENT.md file
+pub fn save_agent(
+    name: &str,
+    frontmatter: &AgentFrontmatter,
+    body: &str,
+) -> BabataResult<()> {
+    let agent_dir = babata_dir()?.join("agents").join(name);
+    std::fs::create_dir_all(&agent_dir).map_err(|err| {
+        BabataError::config(format!(
+            "Failed to create agent directory '{}': {}",
+            agent_dir.display(),
+            err
+        ))
+    })?;
+
+    let agent_path = agent_dir.join("AGENT.md");
+
+    let frontmatter_yaml = serde_yaml::to_string(frontmatter).map_err(|err| {
+        BabataError::config(format!("Failed to serialize agent frontmatter: {}", err))
+    })?;
+
+    let content = format!("---\n{}---\n{}", frontmatter_yaml, body);
+
+    std::fs::write(&agent_path, content).map_err(|err| {
+        BabataError::config(format!(
+            "Failed to write agent file '{}': {}",
+            agent_path.display(),
+            err
+        ))
+    })?;
+
+    Ok(())
+}
+
+/// Delete an agent by name (removes the entire agent directory)
+pub fn delete_agent(name: &str) -> BabataResult<()> {
+    let agent_dir = babata_dir()?.join("agents").join(name);
+
+    if !agent_dir.exists() {
+        return Err(BabataError::config(format!(
+            "Agent '{}' does not exist",
+            name
+        )));
+    }
+
+    std::fs::remove_dir_all(&agent_dir).map_err(|err| {
+        BabataError::config(format!(
+            "Failed to delete agent directory '{}': {}",
+            agent_dir.display(),
+            err
+        ))
+    })?;
+
+    Ok(())
+}
+
+/// Check if an agent exists
+pub fn agent_exists(name: &str) -> bool {
+    match babata_dir() {
+        Ok(dir) => {
+            let agent_path = dir.join("agents").join(name).join("AGENT.md");
+            agent_path.is_file()
+        }
+        Err(_) => false,
+    }
+}
+
+/// Load a single agent by name
+pub fn load_agent_by_name(name: &str) -> BabataResult<Arc<Agent>> {
+    let agent_path = babata_dir()?.join("agents").join(name).join("AGENT.md");
+
+    if !agent_path.is_file() {
+        return Err(BabataError::config(format!(
+            "Agent '{}' not found at '{}'",
+            name,
+            agent_path.display()
+        )));
+    }
+
+    let content = std::fs::read_to_string(&agent_path).map_err(|err| {
+        BabataError::config(format!(
+            "Failed to read agent file '{}': {}",
+            agent_path.display(),
+            err
+        ))
+    })?;
+
+    let (frontmatter, body) = parse_agent_content(&content, &agent_path)?;
+
+    let agent = Agent {
+        path: agent_path,
+        frontmatter,
+        body,
+    };
+
+    Ok(Arc::new(agent))
 }

--- a/src/agent/definition.rs
+++ b/src/agent/definition.rs
@@ -169,10 +169,7 @@ fn parse_agent_content(content: &str, path: &Path) -> BabataResult<(AgentFrontma
 }
 
 /// Save an agent to AGENT.md file
-pub fn save_agent(
-    frontmatter: &AgentFrontmatter,
-    body: &str,
-) -> BabataResult<()> {
+pub fn save_agent(frontmatter: &AgentFrontmatter, body: &str) -> BabataResult<()> {
     let agent_dir = babata_dir()?.join("agents").join(&frontmatter.name);
     std::fs::create_dir_all(&agent_dir).map_err(|err| {
         BabataError::config(format!(

--- a/src/agent/definition.rs
+++ b/src/agent/definition.rs
@@ -170,11 +170,10 @@ fn parse_agent_content(content: &str, path: &Path) -> BabataResult<(AgentFrontma
 
 /// Save an agent to AGENT.md file
 pub fn save_agent(
-    name: &str,
     frontmatter: &AgentFrontmatter,
     body: &str,
 ) -> BabataResult<()> {
-    let agent_dir = babata_dir()?.join("agents").join(name);
+    let agent_dir = babata_dir()?.join("agents").join(&frontmatter.name);
     std::fs::create_dir_all(&agent_dir).map_err(|err| {
         BabataError::config(format!(
             "Failed to create agent directory '{}': {}",

--- a/src/http/create_agent.rs
+++ b/src/http/create_agent.rs
@@ -1,0 +1,75 @@
+use axum::{Json, extract::State};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    BabataResult,
+    agent::{AgentFrontmatter, agent_exists, load_agents, save_agent},
+    error::BabataError,
+};
+
+use super::HttpApp;
+
+pub(super) async fn handle(
+    State(_state): State<HttpApp>,
+    Json(request): Json<CreateAgentRequest>,
+) -> BabataResult<Json<CreateAgentResponse>> {
+    // Validate name is not empty
+    if request.name.trim().is_empty() {
+        return Err(BabataError::invalid_input("name cannot be empty"));
+    }
+
+    // Check if agent already exists
+    if agent_exists(&request.name) {
+        return Err(BabataError::invalid_input(format!(
+            "Agent '{}' already exists",
+            request.name
+        )));
+    }
+
+    // If setting as default, check if another default agent already exists
+    if request.default {
+        let agents = load_agents()?;
+        if agents
+            .values()
+            .any(|agent| agent.frontmatter.default == Some(true))
+        {
+            return Err(BabataError::invalid_input(
+                "Another default agent already exists. Only one agent can be default.",
+            ));
+        }
+    }
+
+    // Create the agent frontmatter
+    let frontmatter = AgentFrontmatter {
+        name: request.name.clone(),
+        description: request.description,
+        provider: request.provider,
+        model: request.model,
+        allowed_tools: request.allowed_tools,
+        default: if request.default { Some(true) } else { None },
+    };
+
+    // Save the agent
+    save_agent(&request.name, &frontmatter, &request.body)?;
+
+    Ok(Json(CreateAgentResponse {
+        name: request.name,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CreateAgentRequest {
+    pub name: String,
+    pub description: String,
+    pub provider: String,
+    pub model: String,
+    pub allowed_tools: Vec<String>,
+    #[serde(default)]
+    pub default: bool,
+    pub body: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CreateAgentResponse {
+    pub name: String,
+}

--- a/src/http/create_agent.rs
+++ b/src/http/create_agent.rs
@@ -50,7 +50,7 @@ pub(super) async fn handle(
     };
 
     // Save the agent
-    save_agent(&request.name, &frontmatter, &request.body)?;
+    save_agent(&frontmatter, &request.body)?;
 
     Ok(StatusCode::CREATED)
 }

--- a/src/http/create_agent.rs
+++ b/src/http/create_agent.rs
@@ -1,4 +1,4 @@
-use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use axum::{Json, extract::State};
 use serde::Deserialize;
 
 use crate::{
@@ -12,7 +12,7 @@ use super::HttpApp;
 pub(super) async fn handle(
     State(_state): State<HttpApp>,
     Json(request): Json<CreateAgentRequest>,
-) -> BabataResult<impl IntoResponse> {
+) -> BabataResult<()> {
     // Validate name is not empty
     if request.name.trim().is_empty() {
         return Err(BabataError::invalid_input("name cannot be empty"));
@@ -52,7 +52,7 @@ pub(super) async fn handle(
     // Save the agent
     save_agent(&frontmatter, &request.body)?;
 
-    Ok(StatusCode::CREATED)
+    Ok(())
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/http/create_agent.rs
+++ b/src/http/create_agent.rs
@@ -1,5 +1,5 @@
-use axum::{Json, extract::State};
-use serde::{Deserialize, Serialize};
+use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use serde::Deserialize;
 
 use crate::{
     BabataResult,
@@ -12,7 +12,7 @@ use super::HttpApp;
 pub(super) async fn handle(
     State(_state): State<HttpApp>,
     Json(request): Json<CreateAgentRequest>,
-) -> BabataResult<Json<CreateAgentResponse>> {
+) -> BabataResult<impl IntoResponse> {
     // Validate name is not empty
     if request.name.trim().is_empty() {
         return Err(BabataError::invalid_input("name cannot be empty"));
@@ -52,9 +52,7 @@ pub(super) async fn handle(
     // Save the agent
     save_agent(&request.name, &frontmatter, &request.body)?;
 
-    Ok(Json(CreateAgentResponse {
-        name: request.name,
-    }))
+    Ok(StatusCode::CREATED)
 }
 
 #[derive(Debug, Deserialize)]
@@ -67,9 +65,4 @@ pub(crate) struct CreateAgentRequest {
     #[serde(default)]
     pub default: bool,
     pub body: String,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct CreateAgentResponse {
-    pub name: String,
 }

--- a/src/http/delete_agent.rs
+++ b/src/http/delete_agent.rs
@@ -1,10 +1,11 @@
 use axum::extract::Path;
 
-use crate::{BabataResult, agent::{agent_exists, delete_agent, load_agents}};
+use crate::{
+    BabataResult,
+    agent::{agent_exists, delete_agent, load_agents},
+};
 
-pub(super) async fn handle(
-    Path(name): Path<String>,
-) -> BabataResult<()> {
+pub(super) async fn handle(Path(name): Path<String>) -> BabataResult<()> {
     // Check if agent exists
     if !agent_exists(&name) {
         return Err(crate::error::BabataError::not_found(format!(
@@ -15,15 +16,15 @@ pub(super) async fn handle(
 
     // Load all agents to check if this is the only agent
     let agents = load_agents()?;
-    
+
     // Check if trying to delete the only default agent
     if let Some(agent) = agents.get(&name) {
         let is_default = agent.frontmatter.default == Some(true);
         let is_only_agent = agents.len() == 1;
-        
+
         if is_default && is_only_agent {
             return Err(crate::error::BabataError::invalid_input(
-                "Cannot delete the only default agent. System must have at least one agent."
+                "Cannot delete the only default agent. System must have at least one agent.",
             ));
         }
     }

--- a/src/http/delete_agent.rs
+++ b/src/http/delete_agent.rs
@@ -1,0 +1,33 @@
+use axum::extract::Path;
+
+use crate::{BabataResult, agent::{agent_exists, delete_agent, load_agents}};
+
+pub(super) async fn handle(
+    Path(name): Path<String>,
+) -> BabataResult<()> {
+    // Check if agent exists
+    if !agent_exists(&name) {
+        return Err(crate::error::BabataError::not_found(format!(
+            "Agent '{}' not found",
+            name
+        )));
+    }
+
+    // Load all agents to check if this is the only agent
+    let agents = load_agents()?;
+    
+    // Check if trying to delete the only default agent
+    if let Some(agent) = agents.get(&name) {
+        let is_default = agent.frontmatter.default == Some(true);
+        let is_only_agent = agents.len() == 1;
+        
+        if is_default && is_only_agent {
+            return Err(crate::error::BabataError::invalid_input(
+                "Cannot delete the only default agent. System must have at least one agent."
+            ));
+        }
+    }
+
+    delete_agent(&name)?;
+    Ok(())
+}

--- a/src/http/get_agent.rs
+++ b/src/http/get_agent.rs
@@ -1,0 +1,43 @@
+use axum::{
+    Json,
+    extract::Path,
+};
+use serde::Serialize;
+
+use crate::BabataResult;
+use crate::agent::load_agent_by_name;
+use crate::error::BabataError;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct GetAgentResponse {
+    pub name: String,
+    pub description: String,
+    pub provider: String,
+    pub model: String,
+    pub allowed_tools: Vec<String>,
+    pub default: bool,
+    pub body: String,
+}
+
+pub(super) async fn handle(
+    Path(name): Path<String>,
+) -> BabataResult<Json<GetAgentResponse>> {
+    let agent = load_agent_by_name(&name).map_err(|err| {
+        // Convert config error (agent not found) to not found error for proper 404 response
+        if err.to_string().contains("not found") {
+            BabataError::not_found(format!("Agent '{}' not found", name))
+        } else {
+            err
+        }
+    })?;
+
+    Ok(Json(GetAgentResponse {
+        name: agent.frontmatter.name.clone(),
+        description: agent.frontmatter.description.clone(),
+        provider: agent.frontmatter.provider.clone(),
+        model: agent.frontmatter.model.clone(),
+        allowed_tools: agent.frontmatter.allowed_tools.clone(),
+        default: agent.frontmatter.default.unwrap_or(false),
+        body: agent.body.clone(),
+    }))
+}

--- a/src/http/get_agent.rs
+++ b/src/http/get_agent.rs
@@ -1,7 +1,4 @@
-use axum::{
-    Json,
-    extract::Path,
-};
+use axum::{Json, extract::Path};
 use serde::Serialize;
 
 use crate::BabataResult;
@@ -19,9 +16,7 @@ pub(crate) struct GetAgentResponse {
     pub body: String,
 }
 
-pub(super) async fn handle(
-    Path(name): Path<String>,
-) -> BabataResult<Json<GetAgentResponse>> {
+pub(super) async fn handle(Path(name): Path<String>) -> BabataResult<Json<GetAgentResponse>> {
     let agent = load_agent_by_name(&name).map_err(|err| {
         // Convert config error (agent not found) to not found error for proper 404 response
         if err.to_string().contains("not found") {

--- a/src/http/list_agents.rs
+++ b/src/http/list_agents.rs
@@ -9,18 +9,8 @@ pub(super) async fn handle() -> BabataResult<Json<ListAgentsResponse>> {
 }
 
 #[derive(Debug, Serialize)]
-pub(crate) struct AgentResponse {
-    pub name: String,
-    pub description: String,
-    pub provider: String,
-    pub model: String,
-    pub allowed_tools: Vec<String>,
-    pub default: bool,
-}
-
-#[derive(Debug, Serialize)]
 pub(crate) struct ListAgentsResponse {
-    pub agents: Vec<AgentResponse>,
+    pub agents: Vec<AgentFrontmatter>,
 }
 
 impl ListAgentsResponse {
@@ -28,21 +18,8 @@ impl ListAgentsResponse {
         Self {
             agents: agents
                 .into_values()
-                .map(|agent| AgentResponse::from_frontmatter(&agent.frontmatter))
+                .map(|agent| agent.frontmatter.clone())
                 .collect(),
-        }
-    }
-}
-
-impl AgentResponse {
-    pub(crate) fn from_frontmatter(frontmatter: &AgentFrontmatter) -> Self {
-        Self {
-            name: frontmatter.name.clone(),
-            description: frontmatter.description.clone(),
-            provider: frontmatter.provider.clone(),
-            model: frontmatter.model.clone(),
-            allowed_tools: frontmatter.allowed_tools.clone(),
-            default: frontmatter.default.unwrap_or(false),
         }
     }
 }

--- a/src/http/list_agents.rs
+++ b/src/http/list_agents.rs
@@ -1,0 +1,48 @@
+use axum::Json;
+use serde::Serialize;
+
+use crate::{BabataResult, agent::{load_agents, AgentFrontmatter}};
+
+pub(super) async fn handle() -> BabataResult<Json<ListAgentsResponse>> {
+    let agents = load_agents()?;
+    Ok(Json(ListAgentsResponse::from_agents(agents)))
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AgentResponse {
+    pub name: String,
+    pub description: String,
+    pub provider: String,
+    pub model: String,
+    pub allowed_tools: Vec<String>,
+    pub default: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ListAgentsResponse {
+    pub agents: Vec<AgentResponse>,
+}
+
+impl ListAgentsResponse {
+    pub(crate) fn from_agents(agents: std::collections::HashMap<String, std::sync::Arc<crate::agent::Agent>>) -> Self {
+        Self {
+            agents: agents
+                .into_values()
+                .map(|agent| AgentResponse::from_frontmatter(&agent.frontmatter))
+                .collect(),
+        }
+    }
+}
+
+impl AgentResponse {
+    pub(crate) fn from_frontmatter(frontmatter: &AgentFrontmatter) -> Self {
+        Self {
+            name: frontmatter.name.clone(),
+            description: frontmatter.description.clone(),
+            provider: frontmatter.provider.clone(),
+            model: frontmatter.model.clone(),
+            allowed_tools: frontmatter.allowed_tools.clone(),
+            default: frontmatter.default.unwrap_or(false),
+        }
+    }
+}

--- a/src/http/list_agents.rs
+++ b/src/http/list_agents.rs
@@ -1,7 +1,10 @@
 use axum::Json;
 use serde::Serialize;
 
-use crate::{BabataResult, agent::{load_agents, AgentFrontmatter}};
+use crate::{
+    BabataResult,
+    agent::{AgentFrontmatter, load_agents},
+};
 
 pub(super) async fn handle() -> BabataResult<Json<ListAgentsResponse>> {
     let agents = load_agents()?;
@@ -14,7 +17,9 @@ pub(crate) struct ListAgentsResponse {
 }
 
 impl ListAgentsResponse {
-    pub(crate) fn from_agents(agents: std::collections::HashMap<String, std::sync::Arc<crate::agent::Agent>>) -> Self {
+    pub(crate) fn from_agents(
+        agents: std::collections::HashMap<String, std::sync::Arc<crate::agent::Agent>>,
+    ) -> Self {
         Self {
             agents: agents
                 .into_values()

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -67,7 +67,10 @@ impl HttpApp {
 fn router(task_manager: Arc<TaskManager>) -> Router {
     Router::new()
         .route("/api/health", get(health))
-        .route("/api/agents", get(list_agents::handle).post(create_agent::handle))
+        .route(
+            "/api/agents",
+            get(list_agents::handle).post(create_agent::handle),
+        )
         .route(
             "/api/agents/{name}",
             get(get_agent::handle)

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,14 +1,19 @@
 mod collaborate_task;
 mod control_task;
 mod count_tasks;
+mod create_agent;
 mod create_task;
+mod delete_agent;
 mod delete_task;
+mod get_agent;
 mod get_task;
 mod get_task_file;
 mod get_task_logs;
+mod list_agents;
 mod list_task_files;
 mod list_tasks;
 mod steer_task;
+mod update_agent;
 
 use std::{env, sync::Arc};
 
@@ -62,6 +67,13 @@ impl HttpApp {
 fn router(task_manager: Arc<TaskManager>) -> Router {
     Router::new()
         .route("/api/health", get(health))
+        .route("/api/agents", get(list_agents::handle).post(create_agent::handle))
+        .route(
+            "/api/agents/{name}",
+            get(get_agent::handle)
+                .put(update_agent::handle)
+                .delete(delete_agent::handle),
+        )
         .route("/api/tasks/count", get(count_tasks::handle))
         .route(
             "/api/tasks",

--- a/src/http/update_agent.rs
+++ b/src/http/update_agent.rs
@@ -1,5 +1,5 @@
 use axum::{Json, extract::Path, http::StatusCode, response::IntoResponse};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::{
     BabataResult,
@@ -15,11 +15,6 @@ pub(crate) struct UpdateAgentRequest {
     pub allowed_tools: Vec<String>,
     pub default: bool,
     pub body: String,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct UpdateAgentResponse {
-    pub name: String,
 }
 
 pub(super) async fn handle(
@@ -57,7 +52,7 @@ pub(super) async fn handle(
     // Save the updated agent
     save_agent(&name, &frontmatter, &request.body)?;
 
-    Ok((StatusCode::OK, Json(UpdateAgentResponse { name })))
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Unset the current default agent (set default to false)
@@ -113,15 +108,5 @@ mod tests {
         assert_eq!(request.allowed_tools, vec!["shell", "read_file"]);
         assert!(request.default);
         assert_eq!(request.body, "Updated agent body");
-    }
-
-    #[test]
-    fn test_update_agent_response_serialization() {
-        let response = UpdateAgentResponse {
-            name: "test-agent".to_string(),
-        };
-
-        let json = serde_json::to_value(&response).unwrap();
-        assert_eq!(json["name"], "test-agent");
     }
 }

--- a/src/http/update_agent.rs
+++ b/src/http/update_agent.rs
@@ -1,4 +1,4 @@
-use axum::{Json, extract::Path, http::StatusCode, response::IntoResponse};
+use axum::{Json, extract::Path};
 use serde::Deserialize;
 
 use crate::{
@@ -20,7 +20,7 @@ pub(crate) struct UpdateAgentRequest {
 pub(super) async fn handle(
     Path(name): Path<String>,
     Json(request): Json<UpdateAgentRequest>,
-) -> BabataResult<impl IntoResponse> {
+) -> BabataResult<()> {
     // Check if agent exists
     if !agent_exists(&name) {
         return Err(BabataError::not_found(format!(
@@ -55,7 +55,7 @@ pub(super) async fn handle(
     // Save the updated agent
     save_agent(&frontmatter, &request.body)?;
 
-    Ok(StatusCode::NO_CONTENT)
+    Ok(())
 }
 
 /// Unset the current default agent (set default to false)

--- a/src/http/update_agent.rs
+++ b/src/http/update_agent.rs
@@ -1,0 +1,127 @@
+use axum::{Json, extract::Path, http::StatusCode, response::IntoResponse};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    BabataResult,
+    agent::{AgentFrontmatter, agent_exists, load_agent_by_name, save_agent},
+    error::BabataError,
+};
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct UpdateAgentRequest {
+    pub description: String,
+    pub provider: String,
+    pub model: String,
+    pub allowed_tools: Vec<String>,
+    pub default: bool,
+    pub body: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct UpdateAgentResponse {
+    pub name: String,
+}
+
+pub(super) async fn handle(
+    Path(name): Path<String>,
+    Json(request): Json<UpdateAgentRequest>,
+) -> BabataResult<impl IntoResponse> {
+    // Check if agent exists
+    if !agent_exists(&name) {
+        return Err(BabataError::not_found(format!("Agent '{}' not found", name)));
+    }
+
+    // Load existing agent to check if default status is changing
+    let existing_agent = load_agent_by_name(&name)?;
+    let old_default = existing_agent.frontmatter.default == Some(true);
+    let new_default = request.default;
+
+    // If setting this agent as default, we need to handle the old default agent
+    if new_default && !old_default {
+        // Unset default on the current default agent
+        if let Err(err) = unset_current_default_agent(&name).await {
+            log::warn!("Failed to unset current default agent: {}", err);
+        }
+    }
+
+    // Build the updated frontmatter
+    let frontmatter = AgentFrontmatter {
+        name: name.clone(),
+        description: request.description,
+        provider: request.provider,
+        model: request.model,
+        allowed_tools: request.allowed_tools,
+        default: Some(new_default),
+    };
+
+    // Save the updated agent
+    save_agent(&name, &frontmatter, &request.body)?;
+
+    Ok((StatusCode::OK, Json(UpdateAgentResponse { name })))
+}
+
+/// Unset the current default agent (set default to false)
+/// This is called when a new agent is being set as default
+async fn unset_current_default_agent(excluding: &str) -> BabataResult<()> {
+    use crate::agent::load_agents;
+
+    let agents = load_agents()?;
+
+    for (agent_name, agent) in agents.iter() {
+        if agent_name == excluding {
+            continue;
+        }
+
+        if agent.frontmatter.default == Some(true) {
+            let new_frontmatter = AgentFrontmatter {
+                name: agent.frontmatter.name.clone(),
+                description: agent.frontmatter.description.clone(),
+                provider: agent.frontmatter.provider.clone(),
+                model: agent.frontmatter.model.clone(),
+                allowed_tools: agent.frontmatter.allowed_tools.clone(),
+                default: Some(false),
+            };
+            save_agent(agent_name, &new_frontmatter, &agent.body)?;
+            log::info!("Unset default agent '{}'", agent_name);
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_update_agent_request_deserialization() {
+        let json = json!({
+            "description": "Updated agent description",
+            "provider": "openai",
+            "model": "gpt-4",
+            "allowed_tools": ["shell", "read_file"],
+            "default": true,
+            "body": "Updated agent body"
+        });
+
+        let request: UpdateAgentRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(request.description, "Updated agent description");
+        assert_eq!(request.provider, "openai");
+        assert_eq!(request.model, "gpt-4");
+        assert_eq!(request.allowed_tools, vec!["shell", "read_file"]);
+        assert!(request.default);
+        assert_eq!(request.body, "Updated agent body");
+    }
+
+    #[test]
+    fn test_update_agent_response_serialization() {
+        let response = UpdateAgentResponse {
+            name: "test-agent".to_string(),
+        };
+
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["name"], "test-agent");
+    }
+}

--- a/src/http/update_agent.rs
+++ b/src/http/update_agent.rs
@@ -50,7 +50,7 @@ pub(super) async fn handle(
     };
 
     // Save the updated agent
-    save_agent(&name, &frontmatter, &request.body)?;
+    save_agent(&frontmatter, &request.body)?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -76,7 +76,7 @@ async fn unset_current_default_agent(excluding: &str) -> BabataResult<()> {
                 allowed_tools: agent.frontmatter.allowed_tools.clone(),
                 default: Some(false),
             };
-            save_agent(agent_name, &new_frontmatter, &agent.body)?;
+            save_agent(&new_frontmatter, &agent.body)?;
             log::info!("Unset default agent '{}'", agent_name);
             break;
         }

--- a/src/http/update_agent.rs
+++ b/src/http/update_agent.rs
@@ -23,7 +23,10 @@ pub(super) async fn handle(
 ) -> BabataResult<impl IntoResponse> {
     // Check if agent exists
     if !agent_exists(&name) {
-        return Err(BabataError::not_found(format!("Agent '{}' not found", name)));
+        return Err(BabataError::not_found(format!(
+            "Agent '{}' not found",
+            name
+        )));
     }
 
     // Load existing agent to check if default status is changing


### PR DESCRIPTION
## Summary
Add HTTP API endpoints for managing agents.

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | /api/agents | List all agents |
| GET | /api/agents/{name} | Get agent details |
| POST | /api/agents | Create new agent |
| PUT | /api/agents/{name} | Update agent (full replacement) |
| DELETE | /api/agents/{name} | Delete agent |

## Changes
- Add save_agent(), delete_agent(), gent_exists(), load_agent_by_name() to definition.rs
- Add Serialize derive to AgentFrontmatter
- Create list_agents.rs, get_agent.rs, create_agent.rs, update_agent.rs, delete_agent.rs
- Register new routes in mod.rs

## Features
- Reuses existing Agent and AgentFrontmatter structs
- Full replacement update (PUT)
- Validates default agent constraints
- Returns proper HTTP status codes (404 for not found, etc.)