### PR TITLE
feat: add skill delete and list APIs

### DIFF
--- a/src/http/delete_skill.rs
+++ b/src/http/delete_skill.rs
@@ -1,0 +1,19 @@
+use axum::extract::Path;
+
+use crate::{
+    BabataResult,
+    skill::{delete_skill, skill_exists},
+};
+
+pub(super) async fn handle(Path(name): Path<String>) -> BabataResult<()> {
+    // Check if skill exists
+    if !skill_exists(&name)? {
+        return Err(crate::error::BabataError::not_found(format!(
+            "Skill '{}' not found",
+            name
+        )));
+    }
+
+    delete_skill(&name)?;
+    Ok(())
+}

--- a/src/http/list_skills.rs
+++ b/src/http/list_skills.rs
@@ -1,0 +1,25 @@
+use axum::Json;
+use serde::Serialize;
+
+use crate::{
+    BabataResult,
+    skill::{SkillFrontmatter, load_skills},
+};
+
+pub(super) async fn handle() -> BabataResult<Json<ListSkillsResponse>> {
+    let skills = load_skills()?;
+    Ok(Json(ListSkillsResponse::from_skills(skills)))
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ListSkillsResponse {
+    pub skills: Vec<SkillFrontmatter>,
+}
+
+impl ListSkillsResponse {
+    pub(crate) fn from_skills(skills: Vec<crate::skill::Skill>) -> Self {
+        Self {
+            skills: skills.into_iter().map(|skill| skill.frontmatter).collect(),
+        }
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -4,12 +4,14 @@ mod count_tasks;
 mod create_agent;
 mod create_task;
 mod delete_agent;
+mod delete_skill;
 mod delete_task;
 mod get_agent;
 mod get_task;
 mod get_task_file;
 mod get_task_logs;
 mod list_agents;
+mod list_skills;
 mod list_task_files;
 mod list_tasks;
 mod steer_task;
@@ -20,7 +22,7 @@ use std::{env, sync::Arc};
 use axum::{
     Json, Router,
     response::IntoResponse,
-    routing::{get, post},
+    routing::{delete, get, post},
 };
 use serde_json::json;
 use tower_http::services::ServeDir;
@@ -77,6 +79,8 @@ fn router(task_manager: Arc<TaskManager>) -> Router {
                 .put(update_agent::handle)
                 .delete(delete_agent::handle),
         )
+        .route("/api/skills", get(list_skills::handle))
+        .route("/api/skills/{name}", delete(delete_skill::handle))
         .route("/api/tasks/count", get(count_tasks::handle))
         .route(
             "/api/tasks",

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -1,13 +1,44 @@
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{BabataResult, error::BabataError, utils::babata_dir};
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SkillFrontmatter {
     pub name: String,
     pub description: String,
+}
+
+/// Get the skill directory path for a given skill name
+fn skill_dir(name: &str) -> BabataResult<PathBuf> {
+    Ok(babata_dir()?.join("skills").join(name))
+}
+
+/// Get the SKILL.md file path for a given skill name
+fn skill_file_path(name: &str) -> BabataResult<PathBuf> {
+    Ok(skill_dir(name)?.join("SKILL.md"))
+}
+
+/// Check if a skill exists by name
+pub fn skill_exists(name: &str) -> BabataResult<bool> {
+    let path = skill_file_path(name)?;
+    Ok(path.exists())
+}
+
+/// Delete a skill by name
+pub fn delete_skill(name: &str) -> BabataResult<()> {
+    let dir = skill_dir(name)?;
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir).map_err(|err| {
+            BabataError::internal(format!(
+                "Failed to delete skill directory '{}': {}",
+                dir.display(),
+                err
+            ))
+        })?;
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
添加 Skill 删除和列表查询接口

## 新增接口

| 方法 | 路径 | 功能 |
|------|------|------|
| GET | /api/skills | 查询所有 skill（只返回 frontmatter） |
| DELETE | /api/skills/{name} | 删除指定 skill |

## 变更内容

- 新增 src/http/list_skills.rs - 列表查询接口
- 新增 src/http/delete_skill.rs - 删除接口
- 修改 src/skill.rs - 添加 Serialize derive 和辅助函数 skill_exists()、delete_skill()
- 修改 src/http/mod.rs - 注册路由

## 检查清单

- [x] 代码编译通过
- [x] 通过 cargo fmt 格式化
- [x] 通过 cargo clippy 检查