### PR TITLE
feat(web): implement dashboard homepage

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,12 +1,367 @@
-.app {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 100vh;
-  text-align: center;
+/* Dashboard 全局样式 */
+* {
+  box-sizing: border-box;
 }
 
-h1 {
-  font-size: 2.5rem;
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, sans-serif;
+  background-color: #f5f5f5;
   color: #333;
+}
+
+.dashboard {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+  min-height: 100vh;
+}
+
+/* 头部 */
+.dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e8e8e8;
+}
+
+.dashboard-header h1 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.last-update {
+  font-size: 13px;
+  color: #888;
+}
+
+.refresh-btn {
+  padding: 8px 16px;
+  border: 1px solid #d9d9d9;
+  border-radius: 6px;
+  background: white;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.refresh-btn:hover:not(:disabled) {
+  border-color: #40a9ff;
+  color: #40a9ff;
+}
+
+.refresh-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* 错误提示 */
+.error-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  background: #fff2f0;
+  border: 1px solid #ffccc7;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  color: #cf1322;
+}
+
+.error-banner button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  color: #cf1322;
+}
+
+/* 统计卡片网格 */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.stats-card {
+  display: flex;
+  align-items: center;
+  padding: 20px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.stats-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.stats-icon {
+  font-size: 32px;
+  margin-right: 16px;
+}
+
+.stats-content {
+  flex: 1;
+}
+
+.stats-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: #1a1a1a;
+  line-height: 1;
+}
+
+.stats-label {
+  font-size: 14px;
+  color: #666;
+  margin-top: 4px;
+}
+
+/* 卡片颜色主题 */
+.stats-card.running .stats-value {
+  color: #52c41a;
+}
+
+.stats-card.total .stats-value {
+  color: #1890ff;
+}
+
+.stats-card.agents .stats-value {
+  color: #722ed1;
+}
+
+.stats-card.skills .stats-value {
+  color: #fa8c16;
+}
+
+/* 创建任务区域 */
+.create-task-section {
+  background: white;
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.create-task-section h2 {
+  margin: 0 0 16px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.create-task-form {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.agent-select {
+  padding: 10px 14px;
+  border: 1px solid #d9d9d9;
+  border-radius: 8px;
+  font-size: 14px;
+  background: white;
+  min-width: 140px;
+  cursor: pointer;
+}
+
+.agent-select:focus {
+  outline: none;
+  border-color: #40a9ff;
+  box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2);
+}
+
+.task-input {
+  flex: 1;
+  min-width: 200px;
+  padding: 10px 14px;
+  border: 1px solid #d9d9d9;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.task-input:focus {
+  outline: none;
+  border-color: #40a9ff;
+  box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2);
+}
+
+.create-btn {
+  padding: 10px 24px;
+  background: #1890ff;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+
+.create-btn:hover:not(:disabled) {
+  background: #40a9ff;
+}
+
+.create-btn:disabled {
+  background: #bfbfbf;
+  cursor: not-allowed;
+}
+
+/* 任务列表区域 */
+.tasks-section {
+  background: white;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.tasks-section h2 {
+  margin: 0 0 16px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a1a1a;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.task-count {
+  font-size: 14px;
+  color: #888;
+  font-weight: normal;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 40px 20px;
+  color: #888;
+}
+
+.empty-state p {
+  margin: 0;
+  font-size: 14px;
+}
+
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.task-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  background: #fafafa;
+  border-radius: 10px;
+  border: 1px solid #f0f0f0;
+  transition: background 0.2s;
+}
+
+.task-item:hover {
+  background: #f5f5f5;
+}
+
+.task-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.task-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.task-description {
+  font-size: 15px;
+  font-weight: 500;
+  color: #1a1a1a;
+  word-break: break-word;
+}
+
+.task-agent {
+  font-size: 13px;
+  color: #666;
+  background: #f0f0f0;
+  padding: 2px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.task-meta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+
+.task-status {
+  font-weight: 500;
+}
+
+.task-time,
+.task-children,
+.task-never-ends {
+  color: #888;
+}
+
+/* 响应式适配 */
+@media (max-width: 768px) {
+  .dashboard {
+    padding: 12px;
+  }
+
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .create-task-form {
+    flex-direction: column;
+  }
+
+  .agent-select,
+  .task-input,
+  .create-btn {
+    width: 100%;
+  }
+
+  .task-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .task-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  .task-meta {
+    gap: 12px;
+  }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,11 +1,317 @@
-import './App.css'
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import './App.css';
+import { api } from './api';
+import type { Task, Agent, Skill } from './types';
 
-function App() {
-  return (
-    <div className="app">
-      <h1>Babata Web UI</h1>
-    </div>
-  )
+// 格式化时间显示
+function formatTimeAgo(timestamp: number): string {
+  const now = Date.now();
+  const diff = now - timestamp * 1000;
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(diff / 86400000);
+
+  if (minutes < 1) return '刚刚';
+  if (minutes < 60) return `${minutes}分钟前`;
+  if (hours < 24) return `${hours}小时前`;
+  return `${days}天前`;
 }
 
-export default App
+// 状态颜色映射
+function getStatusColor(status: string): string {
+  switch (status) {
+    case 'running':
+      return '#52c41a';
+    case 'paused':
+      return '#faad14';
+    case 'failed':
+      return '#f5222d';
+    case 'canceled':
+      return '#8c8c8c';
+    case 'completed':
+      return '#1890ff';
+    default:
+      return '#8c8c8c';
+  }
+}
+
+// 状态文本映射
+function getStatusText(status: string): string {
+  switch (status) {
+    case 'running':
+      return '运行中';
+    case 'paused':
+      return '已暂停';
+    case 'failed':
+      return '失败';
+    case 'canceled':
+      return '已取消';
+    case 'completed':
+      return '已完成';
+    default:
+      return status;
+  }
+}
+
+function App() {
+  // 统计数据
+  const [runningCount, setRunningCount] = useState<number>(0);
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [skills, setSkills] = useState<Skill[]>([]);
+
+  // 任务列表
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [lastUpdate, setLastUpdate] = useState<Date>(new Date());
+
+  // 创建任务表单
+  const [selectedAgent, setSelectedAgent] = useState<string>('');
+  const [taskDescription, setTaskDescription] = useState<string>('');
+  const [isCreating, setIsCreating] = useState<boolean>(false);
+
+  // 加载状态
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 获取统计数据
+  const fetchStats = useCallback(async () => {
+    try {
+      const [runningRes, totalRes, agentsRes, skillsRes] = await Promise.all([
+        api.getRunningTasksCount(),
+        api.getTotalTasksCount(),
+        api.getAgents(),
+        api.getSkills(),
+      ]);
+      setRunningCount(runningRes.count);
+      setTotalCount(totalRes.count);
+      setAgents(agentsRes.agents);
+      setSkills(skillsRes.skills);
+      if (agentsRes.agents.length > 0 && !selectedAgent) {
+        setSelectedAgent(agentsRes.agents[0].name);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '获取统计数据失败');
+    }
+  }, [selectedAgent]);
+
+  // 获取任务列表
+  const fetchTasks = useCallback(async () => {
+    try {
+      const res = await api.getRunningTasks(20);
+      setTasks(res.tasks);
+      setLastUpdate(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '获取任务列表失败');
+    }
+  }, []);
+
+  // 刷新所有数据
+  const refreshData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    await Promise.all([fetchStats(), fetchTasks()]);
+    setIsLoading(false);
+  }, [fetchStats, fetchTasks]);
+
+  // 初始加载
+  useEffect(() => {
+    refreshData();
+  }, [refreshData]);
+
+  // 自动刷新（每10秒）
+  useEffect(() => {
+    const interval = setInterval(() => {
+      fetchStats();
+      fetchTasks();
+    }, 10000);
+    return () => clearInterval(interval);
+  }, [fetchStats, fetchTasks]);
+
+  // 创建任务
+  const handleCreateTask = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedAgent || !taskDescription.trim()) return;
+
+    setIsCreating(true);
+    try {
+      await api.createTask({
+        agent: selectedAgent,
+        prompt: taskDescription.trim(),
+        description: taskDescription.trim(),
+        task_type: 'roottask',
+      });
+      setTaskDescription('');
+      // 刷新任务列表
+      await fetchTasks();
+      await fetchStats();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '创建任务失败');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  // 计算根任务及其子任务数
+  const rootTasksWithChildren = useMemo(() => {
+    // 获取所有根任务（parent_task_id 为 null 或 undefined）
+    const rootTasks = tasks.filter(
+      (task) => !task.parent_task_id || task.parent_task_id === null
+    );
+
+    // 计算每个根任务的子任务数
+    return rootTasks.map((rootTask) => {
+      const childrenCount = tasks.filter(
+        (task) =>
+          task.root_task_id === rootTask.task_id &&
+          task.parent_task_id &&
+          task.parent_task_id !== null
+      ).length;
+      return { ...rootTask, childrenCount };
+    });
+  }, [tasks]);
+
+  return (
+    <div className="dashboard">
+      {/* 头部 */}
+      <header className="dashboard-header">
+        <h1>🧠 Babata System Dashboard</h1>
+        <div className="header-actions">
+          <span className="last-update">
+            最后更新: {lastUpdate.toLocaleTimeString()}
+          </span>
+          <button
+            className="refresh-btn"
+            onClick={refreshData}
+            disabled={isLoading}
+          >
+            {isLoading ? '⏳' : '🔄'} 刷新
+          </button>
+        </div>
+      </header>
+
+      {/* 错误提示 */}
+      {error && (
+        <div className="error-banner">
+          <span>❌ {error}</span>
+          <button onClick={() => setError(null)}>✕</button>
+        </div>
+      )}
+
+      {/* 统计卡片 */}
+      <section className="stats-grid">
+        <div className="stats-card running">
+          <div className="stats-icon">🏃</div>
+          <div className="stats-content">
+            <div className="stats-value">{runningCount}</div>
+            <div className="stats-label">运行中任务</div>
+          </div>
+        </div>
+        <div className="stats-card total">
+          <div className="stats-icon">📋</div>
+          <div className="stats-content">
+            <div className="stats-value">{totalCount}</div>
+            <div className="stats-label">总任务数</div>
+          </div>
+        </div>
+        <div className="stats-card agents">
+          <div className="stats-icon">🤖</div>
+          <div className="stats-content">
+            <div className="stats-value">{agents.length}</div>
+            <div className="stats-label">Agents</div>
+          </div>
+        </div>
+        <div className="stats-card skills">
+          <div className="stats-icon">🛠️</div>
+          <div className="stats-content">
+            <div className="stats-value">{skills.length}</div>
+            <div className="stats-label">Skills</div>
+          </div>
+        </div>
+      </section>
+
+      {/* 快速创建任务 */}
+      <section className="create-task-section">
+        <h2>🚀 快速创建任务</h2>
+        <form className="create-task-form" onSubmit={handleCreateTask}>
+          <select
+            value={selectedAgent}
+            onChange={(e) => setSelectedAgent(e.target.value)}
+            disabled={isCreating || agents.length === 0}
+            className="agent-select"
+          >
+            {agents.map((agent) => (
+              <option key={agent.name} value={agent.name}>
+                🤖 {agent.name}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            placeholder="输入任务描述..."
+            value={taskDescription}
+            onChange={(e) => setTaskDescription(e.target.value)}
+            disabled={isCreating}
+            className="task-input"
+          />
+          <button
+            type="submit"
+            disabled={isCreating || !selectedAgent || !taskDescription.trim()}
+            className="create-btn"
+          >
+            {isCreating ? '⏳ 创建中...' : '➕ 创建'}
+          </button>
+        </form>
+      </section>
+
+      {/* 正在运行的根任务 */}
+      <section className="tasks-section">
+        <h2>
+          ▶️ 正在运行的根任务
+          <span className="task-count">({rootTasksWithChildren.length})</span>
+        </h2>
+        {rootTasksWithChildren.length === 0 ? (
+          <div className="empty-state">
+            <p>📭 暂无运行中的根任务</p>
+          </div>
+        ) : (
+          <div className="task-list">
+            {rootTasksWithChildren.map((task) => (
+              <div key={task.task_id} className="task-item">
+                <div className="task-main">
+                  <div className="task-header">
+                    <span className="task-description">
+                      📄 {task.description}
+                    </span>
+                    <span className="task-agent">🤖 {task.agent}</span>
+                  </div>
+                  <div className="task-meta">
+                    <span
+                      className="task-status"
+                      style={{ color: getStatusColor(task.status) }}
+                    >
+                      🔄 {getStatusText(task.status)}
+                    </span>
+                    <span className="task-time">
+                      ⏱️ {formatTimeAgo(task.created_at)}
+                    </span>
+                    {task.childrenCount > 0 && (
+                      <span className="task-children">
+                        📎 {task.childrenCount}个子任务
+                      </span>
+                    )}
+                    {task.never_ends && (
+                      <span className="task-never-ends">♾️ 常驻</span>
+                    )}
+                  </div>
+                </div>
+
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default App;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,0 +1,57 @@
+// API 客户端
+import type {
+  CountResponse,
+  TasksResponse,
+  AgentsResponse,
+  SkillsResponse,
+  CreateTaskRequest,
+  CreateTaskResponse,
+} from './types';
+
+const API_BASE = '/api';
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+export const api = {
+  // 获取运行中任务数量
+  getRunningTasksCount(): Promise<CountResponse> {
+    return fetchJson<CountResponse>(`${API_BASE}/tasks/count?status=running`);
+  },
+
+  // 获取总任务数量
+  getTotalTasksCount(): Promise<CountResponse> {
+    return fetchJson<CountResponse>(`${API_BASE}/tasks/count`);
+  },
+
+  // 获取 Agent 列表
+  getAgents(): Promise<AgentsResponse> {
+    return fetchJson<AgentsResponse>(`${API_BASE}/agents`);
+  },
+
+  // 获取 Skill 列表
+  getSkills(): Promise<SkillsResponse> {
+    return fetchJson<SkillsResponse>(`${API_BASE}/skills`);
+  },
+
+  // 获取运行中的任务列表
+  getRunningTasks(limit: number = 20): Promise<TasksResponse> {
+    return fetchJson<TasksResponse>(`${API_BASE}/tasks?status=running&limit=${limit}`);
+  },
+
+  // 创建新任务
+  createTask(request: CreateTaskRequest): Promise<CreateTaskResponse> {
+    return fetchJson<CreateTaskResponse>(`${API_BASE}/tasks`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request),
+    });
+  },
+};

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,50 @@
+// API 类型定义
+
+export interface Task {
+  task_id: string;
+  description: string;
+  agent: string;
+  status: 'running' | 'completed' | 'failed' | 'canceled' | 'paused';
+  parent_task_id?: string | null;
+  root_task_id: string;
+  created_at: number;
+  never_ends: boolean;
+}
+
+export interface Agent {
+  name: string;
+  description?: string;
+}
+
+export interface Skill {
+  name: string;
+  description?: string;
+}
+
+export interface CountResponse {
+  count: number;
+}
+
+export interface TasksResponse {
+  tasks: Task[];
+}
+
+export interface AgentsResponse {
+  agents: Agent[];
+}
+
+export interface SkillsResponse {
+  skills: Skill[];
+}
+
+export interface CreateTaskRequest {
+  agent: string;
+  prompt: string;
+  description: string;
+  task_type?: 'roottask' | 'subtask';
+}
+
+export interface CreateTaskResponse {
+  task_id: string;
+  status: string;
+}


### PR DESCRIPTION
## 功能实现

### ✅ 已实现功能

1. **系统状态概览卡片**
   - 🏃 运行中任务数量
   - 📋 总任务数量  
   - 🤖 Agents 数量
   - 🛠️ Skills 数量

2. **快速创建任务**
   - Agent 下拉选择器
   - 任务描述输入框
   - 创建按钮

3. **运行中的根任务列表**
   - 显示任务描述
   - 显示 Agent 名称
   - 显示状态（运行中/已暂停等）
   - 显示创建时间（相对时间，如"5分钟前"）
   - 显示子任务数量
   - 显示常驻任务标记

4. **实时状态刷新**
   - 每 10 秒自动轮询
   - 显示最后更新时间
   - 手动刷新按钮

### 📝 技术说明

- 使用现有后端 API，未添加新接口
- 子任务数通过前端遍历计算
- 响应式设计，支持移动端

### 🔗 相关 API

| 端点 | 用途 |
|------|------|
| GET /api/tasks/count?status=running | 运行中任务数 |
| GET /api/tasks/count | 总任务数 |
| GET /api/agents | Agents 列表 |
| GET /api/skills | Skills 列表 |
| GET /api/tasks?status=running&limit=20 | 运行中任务列表 |
| POST /api/tasks | 创建任务 |
