### PR TITLE
feat: 集成任务管理页面并优化默认 Agent 选择

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { api } from './api';
 import type { Task, Agent, Skill } from './types';
 import { Agents } from './pages/Agents/Agents';
 import { Skills } from './pages/Skills/Skills';
+import { Tasks } from './pages/Tasks/Tasks';
 
 // 格式化时间显示
 function formatTimeAgo(timestamp: number): string {
@@ -350,14 +351,9 @@ function DashboardPage() {
   );
 }
 
-// Tasks 页面占位
+// Tasks 页面
 function TasksPage() {
-  return (
-    <div className="placeholder-page">
-      <h1>📋 任务管理</h1>
-      <p>任务管理页面正在开发中...</p>
-    </div>
-  );
+  return <Tasks />;
 }
 
 // Agents 页面包装器

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -125,7 +125,9 @@ function DashboardPage() {
       setAgents(agentsRes.agents);
       setSkills(skillsRes.skills);
       if (agentsRes.agents.length > 0 && !selectedAgent) {
-        setSelectedAgent(agentsRes.agents[0].name);
+        // 优先选择 default agent，否则选择第一个
+        const defaultAgent = agentsRes.agents.find(a => a.name === 'default');
+        setSelectedAgent(defaultAgent?.name || agentsRes.agents[0].name);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : '获取统计数据失败');


### PR DESCRIPTION
## 变更内容

### 1. 集成真实的任务管理页面
- 在 App.tsx 中导入 Tasks 组件
- 替换 TasksPage 占位符为真实的任务管理页面
- 移除"任务管理页面正在开发中..."占位文本

### 2. 优化首页创建任务的默认 Agent 选择
- 修改 DashboardPage 组件的 agent 默认选中逻辑
- 优先选择名为 'default' 的 agent
- 如不存在 default agent，则回退到选择第一个 agent
- 保持向后兼容性

## 任务管理页面功能
- ✅ 任务列表展示（支持分页）
- ✅ 按状态、Agent、关键词筛选
- ✅ 任务树结构（展开/折叠子任务）
- ✅ 任务控制（暂停/恢复/取消）
- ✅ 任务删除（带确认弹窗）
- ✅ 任务详情查看

## 测试
- ✅ TypeScript 编译成功
- ✅ Vite 构建成功