### PR TITLE
feat: Dashboard 显示运行中的根任务数，移除总任务数卡片

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -94,7 +94,6 @@ function Sidebar({ currentPage, onPageChange }: { currentPage: PageType; onPageC
 function DashboardPage() {
   // 统计数据
   const [runningCount, setRunningCount] = useState<number>(0);
-  const [totalCount, setTotalCount] = useState<number>(0);
   const [agents, setAgents] = useState<Agent[]>([]);
   const [skills, setSkills] = useState<Skill[]>([]);
 
@@ -114,14 +113,12 @@ function DashboardPage() {
   // 获取统计数据
   const fetchStats = useCallback(async () => {
     try {
-      const [runningRes, totalRes, agentsRes, skillsRes] = await Promise.all([
+      const [runningRes, agentsRes, skillsRes] = await Promise.all([
         api.getRunningTasksCount(),
-        api.getTotalTasksCount(),
         api.getAgents(),
         api.getSkills(),
       ]);
       setRunningCount(runningRes.count);
-      setTotalCount(totalRes.count);
       setAgents(agentsRes.agents);
       setSkills(skillsRes.skills);
       if (agentsRes.agents.length > 0 && !selectedAgent) {
@@ -246,11 +243,11 @@ function DashboardPage() {
             <div className="stats-label">运行中任务</div>
           </div>
         </div>
-        <div className="stats-card total">
-          <div className="stats-icon">📋</div>
+        <div className="stats-card root-tasks">
+          <div className="stats-icon">🌳</div>
           <div className="stats-content">
-            <div className="stats-value">{totalCount}</div>
-            <div className="stats-label">总任务数</div>
+            <div className="stats-value">{rootTasksWithChildren.length}</div>
+            <div className="stats-label">运行中的根任务</div>
           </div>
         </div>
         <div className="stats-card agents">


### PR DESCRIPTION
## 变更内容

### 1. 新增运行中的根任务数卡片
- 显示当前正在运行的根任务数量
- 使用 🌳 图标和 "运行中的根任务" 标签
- 基于 rootTasksWithChildren 计算

### 2. 移除总任务数卡片
- 移除总任务数统计卡片（📋 图标）
- 清理未使用的 totalCount 状态
- 移除 getTotalTasksCount API 调用

### 3. 当前 Dashboard 统计卡片布局
| 卡片 | 说明 |
|------|------|
| 🏃 运行中任务 | 保留 - 所有运行中任务数 |
| 🌳 运行中的根任务 | **新增** - 运行中的根任务数 |
| 🤖 Agents | 保留 - Agent 数量 |
| 🛠️ Skills | 保留 - Skill 数量 |

## 测试
- ✅ TypeScript 编译成功
- ✅ Vite 构建成功