### PR TITLE
feat: 添加 React Router 实现多页面路由

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -72,6 +72,7 @@ body {
   transition: all 0.2s;
   text-align: left;
   width: 100%;
+  text-decoration: none;
 }
 
 .nav-item:hover {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { BrowserRouter, Routes, Route, Link, useLocation, Navigate } from 'react-router-dom';
 import './App.css';
 import { api } from './api';
 import type { Task, Agent, Skill } from './types';
@@ -59,14 +60,17 @@ function getStatusText(status: string): string {
 // 导航项类型
 type PageType = 'dashboard' | 'tasks' | 'agents' | 'skills';
 
+// 导航配置
+const navItems: { key: PageType; path: string; label: string; icon: string }[] = [
+  { key: 'dashboard', path: '/', label: 'Dashboard', icon: '📊' },
+  { key: 'tasks', path: '/tasks', label: 'Tasks', icon: '📋' },
+  { key: 'agents', path: '/agents', label: 'Agents', icon: '🤖' },
+  { key: 'skills', path: '/skills', label: 'Skills', icon: '🛠️' },
+];
+
 // 侧边栏导航组件
-function Sidebar({ currentPage, onPageChange }: { currentPage: PageType; onPageChange: (page: PageType) => void }) {
-  const navItems: { key: PageType; label: string; icon: string }[] = [
-    { key: 'dashboard', label: 'Dashboard', icon: '📊' },
-    { key: 'tasks', label: 'Tasks', icon: '📋' },
-    { key: 'agents', label: 'Agents', icon: '🤖' },
-    { key: 'skills', label: 'Skills', icon: '🛠️' },
-  ];
+function Sidebar() {
+  const location = useLocation();
 
   return (
     <aside className="sidebar">
@@ -76,14 +80,14 @@ function Sidebar({ currentPage, onPageChange }: { currentPage: PageType; onPageC
       </div>
       <nav className="sidebar-nav">
         {navItems.map((item) => (
-          <button
+          <Link
             key={item.key}
-            className={`nav-item ${currentPage === item.key ? 'active' : ''}`}
-            onClick={() => onPageChange(item.key)}
+            to={item.path}
+            className={`nav-item ${location.pathname === item.path ? 'active' : ''}`}
           >
             <span className="nav-icon">{item.icon}</span>
             <span className="nav-label">{item.label}</span>
-          </button>
+          </Link>
         ))}
       </nav>
     </aside>
@@ -365,20 +369,30 @@ function SkillsPage() {
   return <Skills />;
 }
 
-// 主应用组件
-function App() {
-  const [currentPage, setCurrentPage] = useState<PageType>('dashboard');
-
+// 应用内容组件（在 Router 内部使用）
+function AppContent() {
   return (
     <div className="app">
-      <Sidebar currentPage={currentPage} onPageChange={setCurrentPage} />
+      <Sidebar />
       <main className="main-content">
-        {currentPage === 'dashboard' && <DashboardPage />}
-        {currentPage === 'tasks' && <TasksPage />}
-        {currentPage === 'agents' && <AgentsPage />}
-        {currentPage === 'skills' && <SkillsPage />}
+        <Routes>
+          <Route path="/" element={<DashboardPage />} />
+          <Route path="/tasks" element={<TasksPage />} />
+          <Route path="/agents" element={<AgentsPage />} />
+          <Route path="/skills" element={<SkillsPage />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
       </main>
     </div>
+  );
+}
+
+// 主应用组件
+function App() {
+  return (
+    <BrowserRouter>
+      <AppContent />
+    </BrowserRouter>
   );
 }
 


### PR DESCRIPTION
## 功能描述

为 Web UI 添加多页面路由支持，使各页面拥有独立 URL，刷新页面时保持在当前页面。

## 变更内容

### 路由配置
| 页面 | URL | 组件 |
|------|-----|------|
| Dashboard | / | DashboardPage |
| Tasks | /tasks | TasksPage |
| Agents | /agents | AgentsPage |
| Skills | /skills | SkillsPage |
| 404 | /* | 重定向到 / |

### 主要修改

#### App.tsx
- 引入 react-router-dom 组件 (BrowserRouter, Routes, Route, Link, useLocation, Navigate)
- 重构 Sidebar 组件：
  - 使用 Link 替换 button
  - 使用 useLocation 获取当前路径
  - 根据 pathname 判断激活状态
- 重构 App 组件：
  - 使用 BrowserRouter 包裹应用
  - 使用 Routes + Route 替换条件渲染
  - 移除 currentPage useState 状态

#### App.css
- 添加 text-decoration: none 到 .nav-item 确保 Link 无下划线

## 优势
- 刷新页面保持在当前页面（不再跳回 Dashboard）
- 支持浏览器前进/后退按钮
- URL 可分享，直接访问特定页面
- 为将来实现页面内锚点、查询参数等功能打基础

## 测试
- ✅ TypeScript 编译成功
- ✅ Vite 构建成功 (119ms)