### PR TITLE
fix: 修复 SPA 页面刷新 404 问题

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // SPA 应用类型，Vite 会自动处理路由刷新
+  appType: 'spa',
+  preview: {
+    // 配置预览服务器端口
+    port: 4173,
+    // 严格模式禁用，允许访问所有 host
+    strictPort: false,
+  },
 })


### PR DESCRIPTION
## 问题描述

使用 React Router 后，刷新任务管理页面 (/tasks)、Agent 管理页面 (/agents)、Skill 管理页面 (/skills) 时出现 HTTP ERROR 404。

## 原因分析

SPA (Single Page Application) 使用前端路由时：
- 点击导航：前端路由拦截，切换页面组件 ✓
- 直接访问/刷新：浏览器向服务器请求该路径，服务器返回 404 ✗

## 解决方案

### 开发/预览环境

配置 Vite 明确指定应用类型为 SPA：



Vite 开发服务器和预览服务器会自动处理路由回退到 index.html。

### 生产环境（重要）

如果使用 Nginx 等服务器部署，需要配置：



或其他服务器相应配置，确保所有路由都指向 index.html。

## 变更内容

- : 
  - 添加  配置
  - 添加  服务器配置

## 测试

- ✅ TypeScript 编译成功
- ✅ Vite 构建成功 (104ms)

## 部署注意事项

如果使用 Nginx 部署，请确保配置：
