### PR TITLE
feat: ignore channel messages older than 1 hour

### DIFF
--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -76,9 +76,22 @@ impl TelegramChannel {
 
     async fn route_incoming(&self, incoming: Vec<IncomingPrivateMessage>) -> Vec<Content> {
         let mut content = Vec::new();
+        let now = chrono::Utc::now().timestamp();
+        let one_hour_ago = now - 3600;
 
         for message in incoming {
             if message.chat_id != self.user_id {
+                continue;
+            }
+
+            if message
+                .timestamp
+                .is_some_and(|ts| ts < one_hour_ago)
+            {
+                warn!(
+                    "Ignoring Telegram message from {} older than 1 hour (timestamp: {:?})",
+                    message.chat_id, message.timestamp
+                );
                 continue;
             }
 
@@ -334,6 +347,8 @@ struct IncomingPrivateMessage {
     image_media_type: Option<String>,
     audio_file_id: Option<String>,
     audio_media_type: Option<String>,
+    /// Unix timestamp in seconds
+    timestamp: Option<i64>,
 }
 
 fn extract_private_messages(
@@ -401,6 +416,7 @@ fn extract_private_messages(
             image_media_type,
             audio_file_id,
             audio_media_type,
+            timestamp: Some(message.date.timestamp()),
         });
     }
 

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -84,12 +84,9 @@ impl TelegramChannel {
                 continue;
             }
 
-            if message
-                .timestamp
-                .is_some_and(|ts| ts < one_hour_ago)
-            {
+            if message.timestamp < one_hour_ago {
                 warn!(
-                    "Ignoring Telegram message from {} older than 1 hour (timestamp: {:?})",
+                    "Ignoring Telegram message from {} older than 1 hour (timestamp: {})",
                     message.chat_id, message.timestamp
                 );
                 continue;
@@ -348,7 +345,7 @@ struct IncomingPrivateMessage {
     audio_file_id: Option<String>,
     audio_media_type: Option<String>,
     /// Unix timestamp in seconds
-    timestamp: Option<i64>,
+    timestamp: i64,
 }
 
 fn extract_private_messages(
@@ -416,7 +413,7 @@ fn extract_private_messages(
             image_media_type,
             audio_file_id,
             audio_media_type,
-            timestamp: Some(message.date.timestamp()),
+            timestamp: message.date.timestamp(),
         });
     }
 

--- a/src/channel/wechat.rs
+++ b/src/channel/wechat.rs
@@ -93,6 +93,8 @@ impl WechatChannel {
 
     async fn route_incoming(&self, incoming: Vec<WechatIncomingMessage>) -> Vec<Content> {
         let mut content = Vec::new();
+        let now = chrono::Utc::now().timestamp();
+        let one_hour_ago = now - 3600;
 
         for message in incoming {
             if message.message_type != WechatProtocolMessageType::User {
@@ -100,6 +102,17 @@ impl WechatChannel {
             }
 
             if message.conversation.user_id != self.user_id {
+                continue;
+            }
+
+            if message
+                .timestamp
+                .is_some_and(|ts| ts < one_hour_ago)
+            {
+                warn!(
+                    "Ignoring Wechat message from {} older than 1 hour (timestamp: {:?})",
+                    message.conversation.user_id, message.timestamp
+                );
                 continue;
             }
 
@@ -651,6 +664,8 @@ struct WechatIncomingMessage {
     message_type: WechatProtocolMessageType,
     message_state: WechatProtocolMessageState,
     items: Vec<WechatMessageItem>,
+    /// Unix timestamp in seconds
+    timestamp: Option<i64>,
 }
 
 impl From<WechatProtocolMessage> for WechatIncomingMessage {
@@ -664,11 +679,22 @@ impl From<WechatProtocolMessage> for WechatIncomingMessage {
             context_token: value.context_token,
         };
 
+        let timestamp = value.create_time_ms.map(|ts| {
+            if ts > 1_000_000_000_000 {
+                // Milliseconds
+                (ts / 1000) as i64
+            } else {
+                // Seconds
+                ts as i64
+            }
+        });
+
         Self {
             conversation,
             message_type: value.message_type.into(),
             message_state: value.message_state.into(),
             items: parse_protocol_items(value.item_list),
+            timestamp,
         }
     }
 }
@@ -925,6 +951,8 @@ struct WechatProtocolMessage {
     context_token: String,
     #[serde(default)]
     item_list: Vec<WechatProtocolItem>,
+    #[serde(default, rename = "create_time_ms")]
+    create_time_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/channel/wechat.rs
+++ b/src/channel/wechat.rs
@@ -105,10 +105,7 @@ impl WechatChannel {
                 continue;
             }
 
-            if message
-                .timestamp
-                .is_some_and(|ts| ts < one_hour_ago)
-            {
+            if message.timestamp.is_some_and(|ts| ts < one_hour_ago) {
                 warn!(
                     "Ignoring Wechat message from {} older than 1 hour (timestamp: {:?})",
                     message.conversation.user_id, message.timestamp


### PR DESCRIPTION
Only process channel messages sent within the last hour. Messages older than 1 hour are ignored with a warning log.