### PR TITLE
feat: add query_messages tool

### DIFF
--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -591,6 +591,53 @@ impl MessageStore {
 
         Ok(messages)
     }
+
+    /// Execute a raw SQL query and return results as JSON array
+    /// Note: This is intended for SELECT queries only. Results are returned as
+    /// an array of JSON objects where keys are column names and values are the data.
+    pub fn query_sql(
+        &self,
+        sql: &str,
+    ) -> BabataResult<Vec<serde_json::Map<String, serde_json::Value>>> {
+        let conn = self.connect()?;
+        let mut stmt = conn
+            .prepare(sql)
+            .map_err(|err| BabataError::tool(format!("Failed to prepare SQL query: {}", err)))?;
+
+        let column_names: Vec<String> = stmt
+            .column_names()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let rows = stmt
+            .query_map([], |row| {
+                let mut obj = serde_json::Map::new();
+                for (idx, col_name) in column_names.iter().enumerate() {
+                    let value = match row.get_ref(idx) {
+                        Ok(rusqlite::types::ValueRef::Null) => serde_json::Value::Null,
+                        Ok(rusqlite::types::ValueRef::Integer(i)) => {
+                            serde_json::Value::Number(i.into())
+                        }
+                        Ok(rusqlite::types::ValueRef::Real(f)) => serde_json::Number::from_f64(f)
+                            .map_or(serde_json::Value::Null, serde_json::Value::Number),
+                        Ok(rusqlite::types::ValueRef::Text(s)) => {
+                            serde_json::Value::String(String::from_utf8_lossy(s).to_string())
+                        }
+                        Ok(rusqlite::types::ValueRef::Blob(_)) => {
+                            serde_json::Value::String("<blob>".to_string())
+                        }
+                        Err(_) => serde_json::Value::Null,
+                    };
+                    obj.insert(col_name.clone(), value);
+                }
+                Ok(obj)
+            })
+            .map_err(|err| BabataError::tool(format!("Failed to execute SQL query: {}", err)))?;
+
+        rows.map(|row| row.map_err(|err| BabataError::tool(format!("Failed to read row: {}", err))))
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -5,6 +5,7 @@ mod delete_tasks;
 mod edit_file;
 mod glob;
 mod grep;
+mod query_messages;
 mod query_tasks;
 mod read_file;
 mod shell;
@@ -22,6 +23,7 @@ pub use delete_tasks::*;
 pub use edit_file::*;
 pub use glob::*;
 pub use grep::*;
+pub use query_messages::*;
 pub use query_tasks::*;
 pub use read_file::*;
 pub use shell::*;
@@ -93,6 +95,7 @@ pub fn build_tools(
         Arc::new(ControlTaskTool::new()?),
         Arc::new(CreateTaskTool::new()?),
         Arc::new(DeleteTasksTool::new()?),
+        Arc::new(QueryMessagesTool::new()),
         Arc::new(QueryTasksTool::new()?),
         Arc::new(WaitTaskTool::new()?),
         Arc::new(SleepTool::new()),

--- a/src/tool/query_messages.rs
+++ b/src/tool/query_messages.rs
@@ -1,0 +1,64 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    BabataResult,
+    memory::MessageStore,
+    tool::{Tool, ToolContext, ToolSpec, parse_tool_args},
+    utils::babata_dir,
+};
+
+#[derive(Debug)]
+pub struct QueryMessagesTool {
+    spec: ToolSpec,
+}
+
+impl QueryMessagesTool {
+    pub fn new() -> Self {
+        Self {
+            spec: ToolSpec {
+                name: "query_messages".to_string(),
+                description: "Query messages from the message store using a SQL SELECT statement. \
+                    Returns each row as a JSON object. \
+                    The messages table has columns: task_id, message_type, content, \
+                    reasoning_content, tool_calls, result, created_at."
+                    .to_string(),
+                parameters: schemars::schema_for!(QueryMessagesArgs),
+            },
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for QueryMessagesTool {
+    fn spec(&self) -> &ToolSpec {
+        &self.spec
+    }
+
+    async fn execute(&self, args: &str, _context: &ToolContext<'_>) -> BabataResult<String> {
+        let QueryMessagesArgs { agent, sql } = parse_tool_args(args)?;
+
+        // Basic validation to ensure it's a SELECT query
+        let trimmed = sql.trim().to_uppercase();
+        if !trimmed.starts_with("SELECT") {
+            return Err(crate::error::BabataError::tool(
+                "Only SELECT queries are allowed".to_string(),
+            ));
+        }
+
+        let babata_home = babata_dir()?;
+        let agent_home = babata_home.join("agents").join(&agent);
+        let store = MessageStore::new(&agent_home)?;
+        let results = store.query_sql(&sql)?;
+        serde_json::to_string(&results).map_err(Into::into)
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct QueryMessagesArgs {
+    #[schemars(description = "The agent name whose message database to query")]
+    agent: String,
+    #[schemars(description = "SQL SELECT query to execute against the messages table")]
+    sql: String,
+}


### PR DESCRIPTION
Add a new \query_messages\ tool that allows querying an agent's message database via SQL SELECT statements. The tool takes \gent\ and \sql\ parameters, similar to \query_tasks\.