### PR TITLE
fix: resolve clippy warning for QueryMessagesTool

### DIFF
--- a/src/tool/query_messages.rs
+++ b/src/tool/query_messages.rs
@@ -13,6 +13,12 @@ pub struct QueryMessagesTool {
     spec: ToolSpec,
 }
 
+impl Default for QueryMessagesTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl QueryMessagesTool {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
Fix clippy warning by adding a \Default\ implementation for \QueryMessagesTool\.\n\n- \cargo fmt\ passes\n- \cargo clippy --all-targets --all-features -- -D warnings\ passes