### PR TITLE
feat: add task_info/task_warn/task_error macros and filter logs by [task_id]

### DIFF
--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
 use backon::{ExponentialBuilder, Retryable};
 use chrono::Utc;
 use futures::future::join_all;
-use log::{info, warn};
+use log::warn;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -65,9 +65,9 @@ impl AgentTask {
             // Check for steer messages before calling the model
             if let Some(steer_rx) = self.steer_rx.as_mut() {
                 while let Ok(steer_msg) = steer_rx.try_recv() {
-                    info!(
-                        "Task {} received steer message with {} content part(s)",
+                    crate::task_info!(
                         self.task_id,
+                        "Received steer message with {} content part(s)",
                         steer_msg.content.len()
                     );
                     conversation.push(Message::UserSteering {
@@ -86,7 +86,7 @@ impl AgentTask {
                 &tool_specs,
             )
             .await?;
-            info!("Provider returned message: {:?}", message);
+            crate::task_info!(self.task_id, "Provider returned message: {:?}", message);
             conversation.push(message.clone());
 
             match message {

--- a/src/http/get_task_logs.rs
+++ b/src/http/get_task_logs.rs
@@ -91,9 +91,10 @@ async fn read_task_logs(
                 let lines: Vec<&str> = content.lines().collect();
                 let mut matching_lines_in_file: Vec<String> = Vec::new();
 
-                // Filter lines containing task_id
+                // Filter lines containing [task_id]
+                let task_marker = format!("[{}]", task_id);
                 for line in &lines {
-                    if line.contains(task_id) {
+                    if line.contains(&task_marker) {
                         matching_lines_in_file.push(line.to_string());
                     }
                 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -6,6 +6,30 @@ use logforth::{
 
 use crate::{BabataResult, error::BabataError, utils::babata_dir};
 
+/// Log an info message prefixed with `[task_id]`.
+#[macro_export]
+macro_rules! task_info {
+    ($task_id:expr, $($arg:tt)*) => {
+        log::info!("[{}] {}", $task_id, std::format_args!($($arg)*))
+    };
+}
+
+/// Log a warn message prefixed with `[task_id]`.
+#[macro_export]
+macro_rules! task_warn {
+    ($task_id:expr, $($arg:tt)*) => {
+        log::warn!("[{}] {}", $task_id, std::format_args!($($arg)*))
+    };
+}
+
+/// Log an error message prefixed with `[task_id]`.
+#[macro_export]
+macro_rules! task_error {
+    ($task_id:expr, $($arg:tt)*) => {
+        log::error!("[{}] {}", $task_id, std::format_args!($($arg)*))
+    };
+}
+
 pub fn init() -> BabataResult<()> {
     match LogOutput::from_env()? {
         LogOutput::File => init_file_logger(),

--- a/src/tool/edit_file.rs
+++ b/src/tool/edit_file.rs
@@ -1,4 +1,3 @@
-use log::info;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use similar::{ChangeTag, TextDiff};
@@ -40,12 +39,12 @@ impl Tool for EditFileTool {
         &self.spec
     }
 
-    async fn execute(&self, args: &str, _context: &ToolContext<'_>) -> BabataResult<String> {
+    async fn execute(&self, args: &str, context: &ToolContext<'_>) -> BabataResult<String> {
         let args: EditFileArgs = parse_tool_args(args)?;
 
         let file_path = shellexpand::tilde(&args.file_path).to_string();
 
-        info!("Editing file: {}", file_path);
+        crate::task_info!(context.task_id, "Editing file: {}", file_path);
 
         let content = tokio::fs::read_to_string(&file_path)
             .await

--- a/src/tool/read_file.rs
+++ b/src/tool/read_file.rs
@@ -6,7 +6,6 @@ use crate::{
     error::BabataError,
     tool::{Tool, ToolContext, ToolSpec, parse_tool_args},
 };
-use log::info;
 
 const DEFAULT_MAX_LINES: usize = 2000;
 
@@ -39,14 +38,14 @@ impl Tool for ReadFileTool {
         &self.spec
     }
 
-    async fn execute(&self, args: &str, _context: &ToolContext<'_>) -> BabataResult<String> {
+    async fn execute(&self, args: &str, context: &ToolContext<'_>) -> BabataResult<String> {
         let args: ReadFileArgs = parse_tool_args(args)?;
         let path = shellexpand::tilde(&args.path).to_string();
 
         let offset = args.offset.unwrap_or(0);
         let limit = args.limit.unwrap_or(DEFAULT_MAX_LINES);
 
-        info!("Reading file: {}", path);
+        crate::task_info!(context.task_id, "Reading file: {}", path);
 
         let content = tokio::fs::read_to_string(&path)
             .await

--- a/src/tool/shell.rs
+++ b/src/tool/shell.rs
@@ -1,6 +1,5 @@
 use std::{path::PathBuf, process::Output, time::Duration};
 
-use log::info;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -39,7 +38,7 @@ impl Tool for ShellTool {
     }
 
     async fn execute(&self, args: &str, context: &ToolContext<'_>) -> BabataResult<String> {
-        info!("Executing shell command: {args}",);
+        crate::task_info!(context.task_id, "Executing shell command: {args}");
 
         let args: ShellArgs = parse_tool_args(args)?;
 

--- a/src/tool/write_file.rs
+++ b/src/tool/write_file.rs
@@ -6,7 +6,6 @@ use crate::{
     error::BabataError,
     tool::{Tool, ToolContext, ToolSpec, parse_tool_args},
 };
-use log::info;
 use std::path::Path;
 
 #[derive(Debug, Clone)]
@@ -38,11 +37,11 @@ impl Tool for WriteFileTool {
         &self.spec
     }
 
-    async fn execute(&self, args: &str, _context: &ToolContext<'_>) -> BabataResult<String> {
+    async fn execute(&self, args: &str, context: &ToolContext<'_>) -> BabataResult<String> {
         let args: WriteFileArgs = parse_tool_args(args)?;
         let path = shellexpand::tilde(&args.path).to_string();
 
-        info!("Writing to file: {}", path);
+        crate::task_info!(context.task_id, "Writing to file: {}", path);
 
         let file_path = Path::new(&path);
 

--- a/web/src/pages/Dashboard/Dashboard.tsx
+++ b/web/src/pages/Dashboard/Dashboard.tsx
@@ -21,6 +21,7 @@ import { StatCard } from "@/components/stat-card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Textarea } from "@/components/ui/textarea"
 import {
   Select,
@@ -107,6 +108,7 @@ export function Dashboard() {
   const [selectedAgent, setSelectedAgent] = useState("")
   const [taskDescription, setTaskDescription] = useState("")
   const [uploadedImages, setUploadedImages] = useState<UploadedImage[]>([])
+  const [neverEnds, setNeverEnds] = useState(false)
   const [isCreating, setIsCreating] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -211,10 +213,12 @@ export function Dashboard() {
         prompt: taskDescription.trim(),
         description: taskDescription.trim(),
         images: uploadedImages.map((image) => image.content),
+        never_ends: neverEnds,
       })
       setTaskDescription("")
       uploadedImages.forEach((image) => URL.revokeObjectURL(image.previewUrl))
       setUploadedImages([])
+      setNeverEnds(false)
       await refreshData()
     } catch (err) {
       setError(err instanceof Error ? err.message : "创建任务失败")
@@ -377,9 +381,29 @@ export function Dashboard() {
               )}
             </div>
 
+            <div className="flex items-center gap-3 rounded-[1.4rem] border border-border/70 bg-background/40 px-4 py-3">
+              <Checkbox
+                id="dashboard-never-ends"
+                checked={neverEnds}
+                onCheckedChange={(checked) => setNeverEnds(checked === true)}
+                disabled={isCreating}
+              />
+              <div className="space-y-1">
+                <label
+                  htmlFor="dashboard-never-ends"
+                  className="text-sm font-medium leading-none text-foreground"
+                >
+                  Never ends
+                </label>
+                <p className="text-sm text-muted-foreground">
+                  勾选后任务会作为常驻任务运行，不会在一次完成后自动结束。
+                </p>
+              </div>
+            </div>
+
             <div className="flex flex-wrap items-center justify-between gap-3">
               <p className="text-sm text-muted-foreground">
-                新任务会以根任务方式创建，并立即进入调度。文本和所有附加图片会一起发送给 Agent。
+                新任务会以根任务方式创建，并立即进入调度。文本、附加图片和常驻设置会一起发送给 Agent。
               </p>
               <Button
                 type="submit"


### PR DESCRIPTION
## Summary

This PR introduces task-specific logging macros and updates the task logs HTTP endpoint to filter logs based on the [task_id] marker.

## Changes

- Added 	ask_info!, 	ask_warn!, and 	ask_error! macros in src/logging.rs that automatically prefix log messages with [task_id].
- Updated src/http/get_task_logs.rs to search for [task_id] instead of the bare 	ask_id string when filtering log lines.
- Migrated several existing log calls in gent/runner.rs and tool modules (shell, ead_file, write_file, edit_file) to use the new 	ask_info! macro for consistent task-attributed logging.

## Rationale

Prefixing task logs with [task_id] makes it easier to correlate log lines with specific tasks. The HTTP API now matches this explicit marker, reducing the chance of accidental matches where the UUID appears in unrelated log content.