### PR TITLE
feat: persist messages incrementally after each model interaction

### DIFF
--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -58,6 +58,8 @@ impl AgentTask {
             content: self.prompt.clone(),
             created_at: Utc::now(),
         }];
+        self.memory
+            .append_messages(self.task_id, &conversation)?;
 
         let mut final_response = None;
         let max_steps = 100;
@@ -70,10 +72,13 @@ impl AgentTask {
                         "Received steer message with {} content part(s)",
                         steer_msg.content.len()
                     );
-                    conversation.push(Message::UserSteering {
+                    let steer_message = Message::UserSteering {
                         content: steer_msg.content,
                         created_at: Utc::now(),
-                    });
+                    };
+                    self.memory
+                        .append_messages(self.task_id, &[steer_message.clone()])?;
+                    conversation.push(steer_message);
                 }
             }
             let message = generate_with_retry(
@@ -87,6 +92,8 @@ impl AgentTask {
             )
             .await?;
             crate::task_info!(self.task_id, "Provider returned message: {:?}", message);
+            self.memory
+                .append_messages(self.task_id, &[message.clone()])?;
             conversation.push(message.clone());
 
             match message {
@@ -132,6 +139,8 @@ impl AgentTask {
                     });
 
                     let results = join_all(tool_futures).await;
+                    self.memory
+                        .append_messages(self.task_id, &results)?;
                     conversation.extend(results);
                 }
                 Message::UserPrompt { .. }
@@ -145,7 +154,6 @@ impl AgentTask {
         }
 
         if let Some(final_response) = final_response {
-            self.memory.append_messages(self.task_id, &conversation)?;
             Ok(final_response)
         } else {
             Err(BabataError::provider(format!(

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -58,8 +58,7 @@ impl AgentTask {
             content: self.prompt.clone(),
             created_at: Utc::now(),
         }];
-        self.memory
-            .append_messages(self.task_id, &conversation)?;
+        self.memory.append_messages(self.task_id, &conversation)?;
 
         let mut final_response = None;
         let max_steps = 100;
@@ -77,7 +76,7 @@ impl AgentTask {
                         created_at: Utc::now(),
                     };
                     self.memory
-                        .append_messages(self.task_id, &[steer_message.clone()])?;
+                        .append_messages(self.task_id, std::slice::from_ref(&steer_message))?;
                     conversation.push(steer_message);
                 }
             }
@@ -93,7 +92,7 @@ impl AgentTask {
             .await?;
             crate::task_info!(self.task_id, "Provider returned message: {:?}", message);
             self.memory
-                .append_messages(self.task_id, &[message.clone()])?;
+                .append_messages(self.task_id, std::slice::from_ref(&message))?;
             conversation.push(message.clone());
 
             match message {
@@ -139,8 +138,7 @@ impl AgentTask {
                     });
 
                     let results = join_all(tool_futures).await;
-                    self.memory
-                        .append_messages(self.task_id, &results)?;
+                    self.memory.append_messages(self.task_id, &results)?;
                     conversation.extend(results);
                 }
                 Message::UserPrompt { .. }


### PR DESCRIPTION
## Summary

Change the agent runner to persist messages incrementally instead of batch-inserting them at the end of a task.

## Changes

- Immediately persist the initial UserPrompt before entering the interaction loop.
- Immediately persist each UserSteering message as it is received.
- Immediately persist the assistant message (AssistantResponse or AssistantToolCalls) right after it is returned by the provider.
- Immediately persist all ToolResult messages right after tool executions finish.
- Removed the batch ppend_messages call at task completion.

## Rationale

Persisting messages incrementally ensures that conversation history is saved to memory even if a task crashes or is interrupted mid-run. This also aligns better with long-running or multi-step tasks where intermediate state visibility is useful.