### PR TITLE
feat: optimize file browser APIs to read directories non-recursively

### DIFF
--- a/src/http/agents.rs
+++ b/src/http/agents.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use super::{
     HttpApp,
-    file_browser::{FileEntry, build_file_request, read_directory_recursive},
+    file_browser::{FileEntry, build_file_request, read_directory},
 };
 
 pub(super) async fn list() -> BabataResult<Json<ListAgentsResponse>> {
@@ -147,7 +147,7 @@ pub(super) async fn list_files(Path(name): Path<String>) -> BabataResult<Json<Ve
         )));
     }
 
-    let files = read_directory_recursive(&agent_dir(&name)?)
+    let files = read_directory(&agent_dir(&name)?, None)
         .await
         .map_err(|err| BabataError::invalid_input(format!("Failed to read directory: {}", err)))?;
 
@@ -172,13 +172,33 @@ async fn get_file_inner(name: &str, file_path: &str, request: Request) -> Babata
         )));
     }
 
-    let forwarded_request = build_file_request(request, file_path)?;
-    let mut service = ServeDir::new(agent_dir(name)?).append_index_html_on_directories(false);
-    service
-        .try_call(forwarded_request)
-        .await
-        .map(IntoResponse::into_response)
-        .map_err(|err| BabataError::internal(format!("Failed to serve agent file: {err}")))
+    let base_dir = agent_dir(name)?;
+    let sanitized_path = file_path.trim_start_matches('/').replace('\\', "/");
+    let target_path = base_dir.join(&sanitized_path);
+
+    match tokio::fs::metadata(&target_path).await {
+        Ok(metadata) if metadata.is_dir() => {
+            let entries = read_directory(&base_dir, Some(&sanitized_path))
+                .await
+                .map_err(|err| {
+                    BabataError::invalid_input(format!("Failed to read directory: {}", err))
+                })?;
+            Ok(Json(entries).into_response())
+        }
+        Ok(metadata) if metadata.is_file() => {
+            let forwarded_request = build_file_request(request, file_path)?;
+            let mut service = ServeDir::new(base_dir).append_index_html_on_directories(false);
+            service
+                .try_call(forwarded_request)
+                .await
+                .map(IntoResponse::into_response)
+                .map_err(|err| BabataError::internal(format!("Failed to serve agent file: {err}")))
+        }
+        _ => Err(BabataError::not_found(format!(
+            "Path '{}' not found",
+            file_path
+        ))),
+    }
 }
 
 fn unset_current_default_agent(excluding: &str) -> BabataResult<()> {

--- a/src/http/file_browser.rs
+++ b/src/http/file_browser.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use axum::{body::Body, extract::Request, http::Uri};
 use serde::Serialize;
@@ -35,47 +35,48 @@ pub(crate) struct FileEntry {
     pub(crate) modified: Option<u64>,
 }
 
-/// Recursively read a directory and return all nested entries using an iterative approach.
-pub(crate) async fn read_directory_recursive(
+/// Read a single directory and return its entries (non-recursive).
+pub(crate) async fn read_directory(
     base_dir: &Path,
+    relative_path: Option<&str>,
 ) -> Result<Vec<FileEntry>, std::io::Error> {
+    let target_dir = if let Some(rel) = relative_path {
+        base_dir.join(rel)
+    } else {
+        base_dir.to_path_buf()
+    };
+
     let mut entries = Vec::new();
-    let mut dirs_to_process: Vec<PathBuf> = vec![base_dir.to_path_buf()];
+    let mut dir_entries = tokio::fs::read_dir(&target_dir).await?;
 
-    while let Some(current_dir) = dirs_to_process.pop() {
-        let mut dir_entries = tokio::fs::read_dir(&current_dir).await?;
+    while let Some(entry) = dir_entries.next_entry().await? {
+        let metadata = entry.metadata().await?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        let full_path = entry.path();
+        let rel_path = full_path
+            .strip_prefix(base_dir)
+            .unwrap_or(&full_path)
+            .to_string_lossy()
+            .to_string()
+            .replace('\\', "/");
+        let is_dir = metadata.is_dir();
 
-        while let Some(entry) = dir_entries.next_entry().await? {
-            let metadata = entry.metadata().await?;
-            let name = entry.file_name().to_string_lossy().to_string();
-            let full_path = entry.path();
-            let rel_path = full_path
-                .strip_prefix(base_dir)
-                .unwrap_or(&full_path)
-                .to_string_lossy()
-                .to_string()
-                .replace('\\', "/");
-            let is_dir = metadata.is_dir();
-
-            entries.push(FileEntry {
-                name: name.clone(),
-                path: rel_path,
-                is_dir,
-                size: if is_dir { None } else { Some(metadata.len()) },
-                modified: metadata
-                    .modified()
-                    .ok()
-                    .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-                    .map(|duration| duration.as_secs()),
-            });
-
-            if is_dir {
-                // Skip directories in the skip list
-                if !SKIP_DIRS.contains(&name.as_str()) {
-                    dirs_to_process.push(full_path);
-                }
-            }
+        // Skip directories in the skip list
+        if is_dir && SKIP_DIRS.contains(&name.as_str()) {
+            continue;
         }
+
+        entries.push(FileEntry {
+            name,
+            path: rel_path,
+            is_dir,
+            size: if is_dir { None } else { Some(metadata.len()) },
+            modified: metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|duration| duration.as_secs()),
+        });
     }
 
     entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
@@ -109,7 +110,7 @@ pub(crate) fn build_file_request(request: Request, file_path: &str) -> BabataRes
 
 #[cfg(test)]
 mod tests {
-    use super::{build_file_request, read_directory_recursive};
+    use super::{build_file_request, read_directory};
     use std::path::PathBuf;
 
     use axum::{
@@ -150,14 +151,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reads_directory_entries_with_relative_paths() {
+    async fn reads_single_directory_non_recursively() {
         let base = std::env::current_dir().expect("current dir").join("src");
         if base.exists() {
-            let entries = read_directory_recursive(&base).await.expect("entries");
+            let entries = read_directory(&base, None).await.expect("entries");
             assert!(!entries.is_empty());
             for entry in &entries {
                 assert!(!entry.path.starts_with('/'));
                 assert!(!entry.path.starts_with('\\'));
+                // Should not contain nested paths (no slashes for direct children)
+                assert!(!entry.path.contains('/'));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn reads_subdirectory_with_relative_path() {
+        let base = std::env::current_dir().expect("current dir");
+        let src = base.join("src");
+        if src.exists() {
+            let entries = read_directory(&base, Some("src")).await.expect("entries");
+            assert!(!entries.is_empty());
+            for entry in &entries {
+                assert!(entry.path.starts_with("src/"));
             }
         }
     }
@@ -165,7 +181,14 @@ mod tests {
     #[tokio::test]
     async fn returns_error_for_missing_directory() {
         let base = PathBuf::from("/nonexistent/path/xyz123");
-        let result = read_directory_recursive(&base).await;
+        let result = read_directory(&base, None).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn returns_error_for_missing_subdirectory() {
+        let base = std::env::current_dir().expect("current dir");
+        let result = read_directory(&base, Some("nonexistent_dir_xyz")).await;
         assert!(result.is_err());
     }
 }

--- a/src/http/get_task_file.rs
+++ b/src/http/get_task_file.rs
@@ -1,4 +1,5 @@
 use axum::{
+    Json,
     extract::{Path, Request, State},
     response::{IntoResponse, Response},
 };
@@ -6,7 +7,11 @@ use tower_http::services::ServeDir;
 
 use crate::{BabataResult, error::BabataError, utils::task_dir};
 
-use super::{HttpApp, ensure_task_exists, file_browser::build_file_request, parse_task_id};
+use super::{
+    HttpApp, ensure_task_exists,
+    file_browser::{build_file_request, read_directory},
+    parse_task_id,
+};
 
 /// Handle GET /api/tasks/{task_id}/files/{*path}
 pub(super) async fn handle(
@@ -30,12 +35,30 @@ async fn handle_inner(
     ensure_task_exists(&state.task_manager, task_id)?;
 
     let task_dir = task_dir(task_id)?;
-    let forwarded_request = build_file_request(request, file_path)?;
+    let sanitized_path = file_path.trim_start_matches('/').replace('\\', "/");
+    let target_path = task_dir.join(&sanitized_path);
 
-    let mut service = ServeDir::new(task_dir).append_index_html_on_directories(false);
-    service
-        .try_call(forwarded_request)
-        .await
-        .map(IntoResponse::into_response)
-        .map_err(|err| BabataError::internal(format!("Failed to serve task file: {err}")))
+    match tokio::fs::metadata(&target_path).await {
+        Ok(metadata) if metadata.is_dir() => {
+            let entries = read_directory(&task_dir, Some(&sanitized_path))
+                .await
+                .map_err(|err| {
+                    BabataError::invalid_input(format!("Failed to read directory: {}", err))
+                })?;
+            Ok(Json(entries).into_response())
+        }
+        Ok(metadata) if metadata.is_file() => {
+            let forwarded_request = build_file_request(request, file_path)?;
+            let mut service = ServeDir::new(task_dir).append_index_html_on_directories(false);
+            service
+                .try_call(forwarded_request)
+                .await
+                .map(IntoResponse::into_response)
+                .map_err(|err| BabataError::internal(format!("Failed to serve task file: {err}")))
+        }
+        _ => Err(BabataError::not_found(format!(
+            "Path '{}' not found",
+            file_path
+        ))),
+    }
 }

--- a/src/http/list_task_files.rs
+++ b/src/http/list_task_files.rs
@@ -7,7 +7,7 @@ use crate::{BabataResult, error::BabataError, utils::task_dir};
 
 use super::{
     HttpApp, ensure_task_exists,
-    file_browser::{FileEntry, read_directory_recursive},
+    file_browser::{FileEntry, read_directory},
     parse_task_id,
 };
 
@@ -25,7 +25,7 @@ pub(super) async fn handle(
         return Ok(Json(Vec::new()));
     }
 
-    let files = read_directory_recursive(&task_dir)
+    let files = read_directory(&task_dir, None)
         .await
         .map_err(|err| BabataError::invalid_input(format!("Failed to read directory: {}", err)))?;
 

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -12,7 +12,7 @@ use crate::{
     skill::{SkillFrontmatter, delete_skill, load_skills, skill_dir, skill_exists},
 };
 
-use super::file_browser::{FileEntry, build_file_request, read_directory_recursive};
+use super::file_browser::{FileEntry, build_file_request, read_directory};
 
 pub(super) async fn list() -> BabataResult<Json<ListSkillsResponse>> {
     let skills = load_skills()?;
@@ -39,7 +39,7 @@ pub(super) async fn list_files(Path(name): Path<String>) -> BabataResult<Json<Ve
         )));
     }
 
-    let files = read_directory_recursive(&skill_dir(&name)?)
+    let files = read_directory(&skill_dir(&name)?, None)
         .await
         .map_err(|err| BabataError::invalid_input(format!("Failed to read directory: {}", err)))?;
 
@@ -64,13 +64,33 @@ async fn get_file_inner(name: &str, file_path: &str, request: Request) -> Babata
         )));
     }
 
-    let forwarded_request = build_file_request(request, file_path)?;
-    let mut service = ServeDir::new(skill_dir(name)?).append_index_html_on_directories(false);
-    service
-        .try_call(forwarded_request)
-        .await
-        .map(IntoResponse::into_response)
-        .map_err(|err| BabataError::internal(format!("Failed to serve skill file: {err}")))
+    let base_dir = skill_dir(name)?;
+    let sanitized_path = file_path.trim_start_matches('/').replace('\\', "/");
+    let target_path = base_dir.join(&sanitized_path);
+
+    match tokio::fs::metadata(&target_path).await {
+        Ok(metadata) if metadata.is_dir() => {
+            let entries = read_directory(&base_dir, Some(&sanitized_path))
+                .await
+                .map_err(|err| {
+                    BabataError::invalid_input(format!("Failed to read directory: {}", err))
+                })?;
+            Ok(Json(entries).into_response())
+        }
+        Ok(metadata) if metadata.is_file() => {
+            let forwarded_request = build_file_request(request, file_path)?;
+            let mut service = ServeDir::new(base_dir).append_index_html_on_directories(false);
+            service
+                .try_call(forwarded_request)
+                .await
+                .map(IntoResponse::into_response)
+                .map_err(|err| BabataError::internal(format!("Failed to serve skill file: {err}")))
+        }
+        _ => Err(BabataError::not_found(format!(
+            "Path '{}' not found",
+            file_path
+        ))),
+    }
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary

- Optimize file directory browsing by reading only the current directory instead of recursively scanning all nested entries.
- Update GET /api/tasks/{task_id}/files, /api/agents/{name}/files, and /api/skills/{name}/files to use non-recursive listing.
- Update GET /files/{path} so that:
  - If the path is a **file**, it returns the file content (existing behavior).
  - If the path is a **directory**, it returns the directory entries as JSON (non-recursive).
- Remove the now-unused ead_directory_recursive() function.
- Add unit tests for the new ead_directory() helper.

## Verification

- cargo fmt ✅
- cargo clippy --all-targets --all-features ✅
- cargo test (148 tests) ✅