### PR TITLE
refactor: remove subtask_count from list root tasks response and UI

### DIFF
--- a/src/http/list_root_tasks.rs
+++ b/src/http/list_root_tasks.rs
@@ -63,11 +63,10 @@ pub(crate) struct RootTaskResponse {
     pub(crate) root_task_id: Uuid,
     pub(crate) created_at: i64,
     pub(crate) never_ends: bool,
-    pub(crate) subtask_count: usize,
 }
 
 impl RootTaskResponse {
-    pub(crate) fn from_record((record, subtask_count): (TaskRecord, usize)) -> Self {
+    pub(crate) fn from_record(record: TaskRecord) -> Self {
         Self {
             task_id: record.task_id,
             description: record.description,
@@ -77,7 +76,6 @@ impl RootTaskResponse {
             root_task_id: record.root_task_id,
             created_at: record.created_at,
             never_ends: record.never_ends,
-            subtask_count,
         }
     }
 }

--- a/src/task/manager.rs
+++ b/src/task/manager.rs
@@ -325,20 +325,11 @@ impl TaskManager {
         status: Option<TaskStatus>,
         limit: usize,
         offset: usize,
-    ) -> BabataResult<(Vec<(TaskRecord, usize)>, usize)> {
+    ) -> BabataResult<(Vec<TaskRecord>, usize)> {
         let tasks = self.store.list_root_tasks(status, limit, offset)?;
         let total = self.store.count_root_tasks(status)?;
 
-        // Get subtask count for each task
-        let tasks_with_count: Vec<(TaskRecord, usize)> = tasks
-            .into_iter()
-            .map(|task| {
-                let count = self.store.count_subtasks(task.task_id).unwrap_or(0);
-                (task, count)
-            })
-            .collect();
-
-        Ok((tasks_with_count, total))
+        Ok((tasks, total))
     }
 
     /// Get children of a task

--- a/web/src/pages/Tasks/Tasks.tsx
+++ b/web/src/pages/Tasks/Tasks.tsx
@@ -275,7 +275,6 @@ export function Tasks() {
 
                         <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-muted-foreground">
                           <span>创建于 {formatTime(task.created_at)}</span>
-                          <span>{task.subtask_count} 个子任务</span>
                         </div>
                       </button>
                     )

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -16,7 +16,6 @@ export interface Task {
 }
 
 export interface RootTask extends Task {
-  subtask_count: number;
   children?: Task[];
 }
 


### PR DESCRIPTION
- Remove subtask_count from list_root_tasks API response (use TaskRecord directly)
- Remove subtask_count query logic from TaskManager::list_root_tasks
- Remove subtask_count from web RootTask type
- Remove subtask count display from Tasks page UI