### PR TITLE
feat: add babata version to environment prompt

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,29 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs");
+
+    if let Some(commit_id) = git_commit_id() {
+        println!("cargo:rustc-env=BABATA_GIT_COMMIT={commit_id}");
+    }
+}
+
+fn git_commit_id() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let commit_id = String::from_utf8(output.stdout).ok()?;
+    let commit_id = commit_id.trim();
+    if commit_id.is_empty() {
+        return None;
+    }
+
+    Some(commit_id.to_string())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use babata::{
     http::HttpApp,
     message::Content,
     task::{CreateTaskRequest, TaskLauncher, TaskManager, TaskStore},
-    utils::babata_dir,
+    utils::{babata_dir, build_commit},
 };
 use log::info;
 
@@ -39,8 +39,9 @@ async fn main() -> BabataResult<()> {
 
 async fn broadcast_service_started(task_manager: &Arc<TaskManager>) -> BabataResult<()> {
     let notification = format!(
-        "Babata server started.\nVersion: {}\nBabata home: {}",
+        "Babata server started.\nVersion: {}\nBuild commit: {}\nBabata home: {}",
         env!("CARGO_PKG_VERSION"),
+        build_commit().unwrap_or("unknown"),
         babata_dir()?.display(),
     );
 

--- a/src/system_prompt/mod.rs
+++ b/src/system_prompt/mod.rs
@@ -50,14 +50,16 @@ pub fn build_environment_prompt(task_id: Uuid) -> BabataResult<String> {
 - Current working directory(CWD): {}
 - User time zone: {}
 - Operating system: {}
-- CPU architecture: {}"#,
+- CPU architecture: {}
+- Babata version: {}"#,
         user_home_dir()?.display(),
         babata_dir()?.display(),
         task_dir(task_id)?.display(),
         std::env::current_dir()?.display(),
         now.format("%Z (%:z)"),
         std::env::consts::OS,
-        std::env::consts::ARCH
+        std::env::consts::ARCH,
+        env!("CARGO_PKG_VERSION")
     ))
 }
 

--- a/src/system_prompt/mod.rs
+++ b/src/system_prompt/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     channel::ChannelConfig,
     skill::Skill,
     tool::ToolSpec,
-    utils::{babata_dir, channel_dir, task_dir, user_home_dir},
+    utils::{babata_dir, build_commit, channel_dir, task_dir, user_home_dir},
 };
 use chrono::Local;
 use uuid::Uuid;
@@ -41,7 +41,6 @@ pub fn build_system_prompts(
 }
 
 pub fn build_environment_prompt(task_id: Uuid) -> BabataResult<String> {
-    let now = Local::now();
     Ok(format!(
         r#"# Environment
 - User home directory(USER_HOME): {}
@@ -51,15 +50,17 @@ pub fn build_environment_prompt(task_id: Uuid) -> BabataResult<String> {
 - User time zone: {}
 - Operating system: {}
 - CPU architecture: {}
-- Babata version: {}"#,
+- Babata version: {}
+- Babata build commit: {}"#,
         user_home_dir()?.display(),
         babata_dir()?.display(),
         task_dir(task_id)?.display(),
         std::env::current_dir()?.display(),
-        now.format("%Z (%:z)"),
+        Local::now().format("%Z (%:z)"),
         std::env::consts::OS,
         std::env::consts::ARCH,
-        env!("CARGO_PKG_VERSION")
+        env!("CARGO_PKG_VERSION"),
+        build_commit().unwrap_or("unknown"),
     ))
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -40,3 +40,10 @@ pub fn channel_dir(channel_name: &str) -> BabataResult<PathBuf> {
 pub fn agent_dir(agent_name: &str) -> BabataResult<PathBuf> {
     Ok(babata_dir()?.join("agents").join(agent_name))
 }
+
+pub const fn build_commit() -> Option<&'static str> {
+    match option_env!("BABATA_GIT_COMMIT") {
+        Some(commit_id) if !commit_id.is_empty() => Some(commit_id),
+        _ => None,
+    }
+}


### PR DESCRIPTION
Closes #137. Adds Babata version information to the environment prompt provided to agents.