### PR TITLE
fix: prioritize channel feedback before stale filtering

### DIFF
--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -93,14 +93,6 @@ impl TelegramChannel {
                 continue;
             }
 
-            if message.timestamp < one_hour_ago {
-                warn!(
-                    "Ignoring Telegram message from {} older than 1 hour (timestamp: {})",
-                    message.chat_id, message.timestamp
-                );
-                continue;
-            }
-
             let mut message_content = self.incoming_message_to_content(&message).await?;
             if message_content.is_empty() {
                 continue;
@@ -114,6 +106,14 @@ impl TelegramChannel {
                     .remove(&reply_to_message_id)
             {
                 let _ = waiter.send(message_content);
+                continue;
+            }
+
+            if message.timestamp < one_hour_ago {
+                warn!(
+                    "Ignoring Telegram message from {} older than 1 hour (timestamp: {})",
+                    message.chat_id, message.timestamp
+                );
                 continue;
             }
 
@@ -848,5 +848,76 @@ mod tests {
             private_messages[0].audio_media_type,
             Some("audio/ogg".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn route_incoming_delivers_stale_feedback_reply_before_stale_filter() {
+        let channel = TelegramChannel::new(crate::channel::TelegramChannelConfig {
+            name: "telegram-main".to_string(),
+            bot_token: "token".to_string(),
+            user_id: 1001,
+        })
+        .expect("channel");
+
+        let (sender, receiver) = oneshot::channel();
+        channel.feedback_waiters.lock().await.insert(42, sender);
+
+        let stale_timestamp = chrono::Utc::now().timestamp() - 7200;
+        let incoming = vec![IncomingPrivateMessage {
+            chat_id: 1001,
+            timestamp: stale_timestamp,
+            text: Some("reply body".to_string()),
+            image_file_id: None,
+            image_media_type: None,
+            audio_file_id: None,
+            audio_media_type: None,
+            reply_to_message_id: Some(42),
+            reply_to_message_content: Some(vec![Content::Text {
+                text: "quoted".to_string(),
+            }]),
+        }];
+
+        let routed = channel
+            .route_incoming(incoming)
+            .await
+            .expect("route incoming");
+        assert!(routed.is_empty());
+
+        let delivered = receiver.await.expect("feedback delivery");
+        assert_eq!(
+            delivered,
+            vec![Content::Text {
+                text: "reply body".to_string()
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn route_incoming_drops_stale_non_feedback_message() {
+        let channel = TelegramChannel::new(crate::channel::TelegramChannelConfig {
+            name: "telegram-main".to_string(),
+            bot_token: "token".to_string(),
+            user_id: 1001,
+        })
+        .expect("channel");
+
+        let stale_timestamp = chrono::Utc::now().timestamp() - 7200;
+        let incoming = vec![IncomingPrivateMessage {
+            chat_id: 1001,
+            timestamp: stale_timestamp,
+            text: Some("normal stale message".to_string()),
+            image_file_id: None,
+            image_media_type: None,
+            audio_file_id: None,
+            audio_media_type: None,
+            reply_to_message_id: None,
+            reply_to_message_content: None,
+        }];
+
+        let routed = channel
+            .route_incoming(incoming)
+            .await
+            .expect("route incoming");
+        assert!(routed.is_empty());
     }
 }

--- a/src/channel/wechat.rs
+++ b/src/channel/wechat.rs
@@ -88,13 +88,12 @@ impl WechatChannel {
                 continue;
             }
 
-            self.persist_latest_context_token(&message.context_token)?;
-
             let message_content = self.incoming_message_to_content(&message).await?;
 
             if let Some(hash) = extract_quote_hash(&message)
                 && let Some(waiter) = self.feedback_waiters.lock().await.remove(&hash)
             {
+                self.persist_latest_context_token(&message.context_token)?;
                 let _ = waiter.send(message_content);
                 continue;
             }
@@ -107,6 +106,7 @@ impl WechatChannel {
                 continue;
             }
 
+            self.persist_latest_context_token(&message.context_token)?;
             content.extend(message_content);
         }
 
@@ -679,6 +679,71 @@ mod tests {
             .await
             .expect("route incoming");
         assert!(routed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn route_incoming_stale_non_feedback_message_does_not_persist_latest_context_token() {
+        let unique_name = format!("wechat-stale-no-persist-{}", uuid::Uuid::new_v4());
+        let latest_context_token_path = WechatChannel::latest_context_token_path(&unique_name)
+            .expect("latest context token path");
+        let parent_dir = latest_context_token_path
+            .parent()
+            .expect("channel directory")
+            .to_path_buf();
+        if parent_dir.exists() {
+            std::fs::remove_dir_all(&parent_dir).expect("cleanup existing channel directory");
+        }
+
+        let channel = WechatChannel::new(crate::channel::WechatChannelConfig {
+            name: unique_name.clone(),
+            bot_token: "token".to_string(),
+            user_id: "wxid_user".to_string(),
+        })
+        .expect("channel");
+
+        write_text_file(&latest_context_token_path, "existing-token")
+            .expect("seed latest context token");
+
+        let stale_timestamp = SystemTime::now()
+            .checked_sub(Duration::from_secs(7200))
+            .expect("stale timestamp");
+
+        let incoming = vec![IncomingMessage {
+            user_id: "wxid_user".to_string(),
+            text: "normal stale message".to_string(),
+            content_type: wechatbot::types::ContentType::Text,
+            timestamp: stale_timestamp,
+            images: Vec::new(),
+            voices: Vec::new(),
+            files: Vec::new(),
+            videos: Vec::new(),
+            quoted: None,
+            raw: WireMessage {
+                from_user_id: "wxid_user".to_string(),
+                to_user_id: "wxid_bot".to_string(),
+                client_id: "client".to_string(),
+                create_time_ms: 1,
+                message_type: wechatbot::types::MessageType::User,
+                message_state: MessageState::Finish,
+                context_token: "ctx-stale-normal-new".to_string(),
+                item_list: Vec::new(),
+            },
+            context_token: "ctx-stale-normal-new".to_string(),
+        }];
+
+        let routed = channel
+            .route_incoming(incoming)
+            .await
+            .expect("route incoming");
+        assert!(routed.is_empty());
+
+        let persisted = read_optional_trimmed_text(&latest_context_token_path)
+            .expect("read latest context token");
+        assert_eq!(persisted.as_deref(), Some("existing-token"));
+
+        if parent_dir.exists() {
+            std::fs::remove_dir_all(&parent_dir).expect("cleanup channel directory");
+        }
     }
 
     #[test]

--- a/src/channel/wechat.rs
+++ b/src/channel/wechat.rs
@@ -88,14 +88,6 @@ impl WechatChannel {
                 continue;
             }
 
-            if message.timestamp < one_hour_ago {
-                warn!(
-                    "Ignoring Wechat message from {} older than 1 hour (timestamp: {:?})",
-                    message.user_id, message.timestamp
-                );
-                continue;
-            }
-
             self.persist_latest_context_token(&message.context_token)?;
 
             let message_content = self.incoming_message_to_content(&message).await?;
@@ -104,6 +96,14 @@ impl WechatChannel {
                 && let Some(waiter) = self.feedback_waiters.lock().await.remove(&hash)
             {
                 let _ = waiter.send(message_content);
+                continue;
+            }
+
+            if message.timestamp < one_hour_ago {
+                warn!(
+                    "Ignoring Wechat message from {} older than 1 hour (timestamp: {:?})",
+                    message.user_id, message.timestamp
+                );
                 continue;
             }
 
@@ -577,6 +577,108 @@ mod tests {
             &content[0],
             Content::Text { text } if text == "> quoted\nfirst\nvoice text"
         ));
+    }
+
+    #[tokio::test]
+    async fn route_incoming_delivers_stale_feedback_reply_before_stale_filter() {
+        let channel = WechatChannel::new(crate::channel::WechatChannelConfig {
+            name: "wechat-main".to_string(),
+            bot_token: "token".to_string(),
+            user_id: "wxid_user".to_string(),
+        })
+        .expect("channel");
+
+        let (sender, receiver) = oneshot::channel();
+        channel
+            .feedback_waiters
+            .lock()
+            .await
+            .insert(hash_feedback_key("quoted"), sender);
+
+        let stale_timestamp = SystemTime::now()
+            .checked_sub(Duration::from_secs(7200))
+            .expect("stale timestamp");
+
+        let incoming = vec![IncomingMessage {
+            user_id: "wxid_user".to_string(),
+            text: "reply body".to_string(),
+            content_type: wechatbot::types::ContentType::Text,
+            timestamp: stale_timestamp,
+            images: Vec::new(),
+            voices: Vec::new(),
+            files: Vec::new(),
+            videos: Vec::new(),
+            quoted: Some(QuotedMessage {
+                title: None,
+                text: Some("quoted".to_string()),
+            }),
+            raw: WireMessage {
+                from_user_id: "wxid_user".to_string(),
+                to_user_id: "wxid_bot".to_string(),
+                client_id: "client".to_string(),
+                create_time_ms: 1,
+                message_type: wechatbot::types::MessageType::User,
+                message_state: MessageState::Finish,
+                context_token: "ctx-stale-feedback".to_string(),
+                item_list: Vec::new(),
+            },
+            context_token: "ctx-stale-feedback".to_string(),
+        }];
+
+        let routed = channel
+            .route_incoming(incoming)
+            .await
+            .expect("route incoming");
+        assert!(routed.is_empty());
+
+        let delivered = receiver.await.expect("feedback delivery");
+        assert!(matches!(
+            delivered.first(),
+            Some(Content::Text { text }) if text == "> quoted\nreply body"
+        ));
+    }
+
+    #[tokio::test]
+    async fn route_incoming_drops_stale_non_feedback_message() {
+        let channel = WechatChannel::new(crate::channel::WechatChannelConfig {
+            name: "wechat-main".to_string(),
+            bot_token: "token".to_string(),
+            user_id: "wxid_user".to_string(),
+        })
+        .expect("channel");
+
+        let stale_timestamp = SystemTime::now()
+            .checked_sub(Duration::from_secs(7200))
+            .expect("stale timestamp");
+
+        let incoming = vec![IncomingMessage {
+            user_id: "wxid_user".to_string(),
+            text: "normal stale message".to_string(),
+            content_type: wechatbot::types::ContentType::Text,
+            timestamp: stale_timestamp,
+            images: Vec::new(),
+            voices: Vec::new(),
+            files: Vec::new(),
+            videos: Vec::new(),
+            quoted: None,
+            raw: WireMessage {
+                from_user_id: "wxid_user".to_string(),
+                to_user_id: "wxid_bot".to_string(),
+                client_id: "client".to_string(),
+                create_time_ms: 1,
+                message_type: wechatbot::types::MessageType::User,
+                message_state: MessageState::Finish,
+                context_token: "ctx-stale-normal".to_string(),
+                item_list: Vec::new(),
+            },
+            context_token: "ctx-stale-normal".to_string(),
+        }];
+
+        let routed = channel
+            .route_incoming(incoming)
+            .await
+            .expect("route incoming");
+        assert!(routed.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- check feedback replies before stale-message filtering in WeChat and Telegram channel routing
- allow stale feedback replies to reach waiting feedback prompts
- keep stale non-feedback messages filtered out
- prevent stale non-feedback WeChat messages from overwriting `latest_context_token`
- add regression tests for both channel implementations and the WeChat token persistence edge case

## Verification
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test