### PR TITLE
refactor: consolidate task completion decision logic in TaskManager

### DIFF
--- a/src/task/manager.rs
+++ b/src/task/manager.rs
@@ -481,21 +481,28 @@ impl TaskManager {
             return;
         }
 
-        if self.has_unfinished_subtasks(task_id) {
-            let reason = format!(
-                "Task {} is being relaunched because it attempted to finish while there are still unfinished subtasks. A parent task must remain running until all of its subtasks are completed, failed, or canceled.",
-                task.task_id
-            );
-            self.relaunch_after_completion(&task, &reason, "deferred completion");
-            return;
-        }
+        let completion_action = if self.has_unfinished_subtasks(task_id) {
+            Some((
+                format!(
+                    "Task {} is being relaunched because it attempted to finish while there are still unfinished subtasks. A parent task must remain running until all of its subtasks are completed, failed, or canceled.",
+                    task.task_id
+                ),
+                "deferred completion",
+            ))
+        } else if task.never_ends {
+            Some((
+                format!(
+                    "Task {} is being relaunched because it is configured with never_ends=true and should keep running after reporting completion.",
+                    task.task_id
+                ),
+                "never-ending completion",
+            ))
+        } else {
+            None
+        };
 
-        if task.never_ends {
-            let reason = format!(
-                "Task {} is being relaunched because it is configured with never_ends=true and should keep running after reporting completion.",
-                task.task_id
-            );
-            self.relaunch_after_completion(&task, &reason, "never-ending completion");
+        if let Some((reason, context)) = completion_action {
+            self.relaunch_after_completion(&task, &reason, context);
             return;
         }
 


### PR DESCRIPTION
## Description
Consolidated the logic for determining whether a task should be relaunched after completion in TaskManager::handle_task_completed.

## Motivation
Previously, multiple separate if blocks were used to check for unfinished subtasks and the 
ever_ends flag, each calling elaunch_after_completion and returning early. This fragmented the decision logic. The refactor introduces a completion_action variable to decouple the decision logic from the execution of the relaunch.

## Verification
- cargo fmt: Passed
- cargo clippy: Passed
- cargo test: Passed (core logic verified)