### PR TITLE
Fix: truncate long task description in delete confirm modal

### DIFF
--- a/web/src/components/DeleteConfirmModal.tsx
+++ b/web/src/components/DeleteConfirmModal.tsx
@@ -66,11 +66,13 @@ export function DeleteConfirmModal({
             </div>
           </div>
 
-          <div className="rounded-[1.4rem] border border-border/70 bg-background/70 p-4 text-sm text-muted-foreground">
+          <div className="rounded-[1.4rem] border border-border/70 bg-background/70 p-4 text-sm text-muted-foreground min-w-0 max-w-full">
             {taskDescription ? (
-              <div className="mb-2">
+              <div className="mb-2 overflow-hidden">
                 <span className="font-medium text-foreground">任务描述：</span>
-                {taskDescription}
+                <div className="line-clamp-2 break-words" title={taskDescription}>
+                  {taskDescription}
+                </div>
               </div>
             ) : null}
             <div className="font-mono text-xs text-muted-foreground">Task ID: {taskId}</div>


### PR DESCRIPTION
## Problem

Long task descriptions in the delete confirmation modal were not being truncated properly, causing layout issues.

## Changes

- Add min-w-0 max-w-full to container for width constraints
- Add overflow-hidden to description wrapper
- Use line-clamp-2 and reak-words for text truncation
- Add 	itle attribute for hover tooltip showing full text