### PR TITLE
refactor: swap stat card positions for running tasks and root tasks

### DIFF
--- a/web/src/components/DeleteConfirmModal.tsx
+++ b/web/src/components/DeleteConfirmModal.tsx
@@ -66,11 +66,13 @@ export function DeleteConfirmModal({
             </div>
           </div>
 
-          <div className="rounded-[1.4rem] border border-border/70 bg-background/70 p-4 text-sm text-muted-foreground">
+          <div className="rounded-[1.4rem] border border-border/70 bg-background/70 p-4 text-sm text-muted-foreground min-w-0 max-w-full">
             {taskDescription ? (
-              <div className="mb-2">
+              <div className="mb-2 overflow-hidden">
                 <span className="font-medium text-foreground">任务描述：</span>
-                {taskDescription}
+                <div className="line-clamp-2 break-words" title={taskDescription}>
+                  {taskDescription}
+                </div>
               </div>
             ) : null}
             <div className="font-mono text-xs text-muted-foreground">Task ID: {taskId}</div>

--- a/web/src/pages/Dashboard/Dashboard.tsx
+++ b/web/src/pages/Dashboard/Dashboard.tsx
@@ -271,8 +271,8 @@ export function Dashboard() {
       ) : null}
 
       <section className="grid gap-4 xl:grid-cols-5 md:grid-cols-2">
-        <StatCard icon={Activity} label="运行中任务" value={runningCount} tone="amber" />
         <StatCard icon={Workflow} label="运行中根任务" value={rootTasksWithChildren.length} tone="primary" />
+        <StatCard icon={Activity} label="运行中任务" value={runningCount} tone="amber" />
         <StatCard icon={Bot} label="Agents" value={agents.length} tone="cyan" />
         <StatCard icon={PlugZap} label="Providers" value={providers.length} tone="emerald" />
         <StatCard icon={Package2} label="Skills" value={skills.length} tone="rose" />


### PR DESCRIPTION
## 改动

Dashboard 页面统计卡片区域，将 "运行中根任务" 和 "运行中任务" 的位置互换。

### 修改前
- 运行中任务 → 运行中根任务 → Agents → Providers → Skills

### 修改后
- 运行中根任务 → 运行中任务 → Agents → Providers → Skills

## 验证
- `npm run build` 编译通过
