### PR TITLE
feat(provider): support URL image source and typed role enum for Anthropic API

### DIFF
--- a/src/provider/anthropic_compatible.rs
+++ b/src/provider/anthropic_compatible.rs
@@ -54,8 +54,7 @@ impl AnthropicCompatibleProvider {
                 ))
             }
             Content::ImageData { data, media_type } => Ok(AnthropicContentBlock::Image {
-                source: AnthropicImageSource {
-                    source_type: "base64".to_string(),
+                source: AnthropicImageSource::Base64 {
                     media_type: media_type.as_mime_str(),
                     data: data.clone(),
                 },
@@ -87,7 +86,7 @@ impl AnthropicCompatibleProvider {
                             }
                         }
                     }
-                    ("user", blocks)
+                    (AnthropicRole::User, blocks)
                 }
                 Message::AssistantToolCalls {
                     calls,
@@ -106,7 +105,7 @@ impl AnthropicCompatibleProvider {
                             }
                         })
                         .collect();
-                    ("assistant", blocks)
+                    (AnthropicRole::Assistant, blocks)
                 }
                 Message::AssistantResponse {
                     content,
@@ -123,10 +122,10 @@ impl AnthropicCompatibleProvider {
                             }
                         }
                     }
-                    ("assistant", blocks)
+                    (AnthropicRole::Assistant, blocks)
                 }
                 Message::ToolResult { call, result, .. } => (
-                    "user",
+                    AnthropicRole::User,
                     vec![AnthropicContentBlock::ToolResult {
                         tool_use_id: call.call_id.clone(),
                         content: result.clone(),
@@ -147,7 +146,7 @@ impl AnthropicCompatibleProvider {
             }
 
             request_messages.push(AnthropicMessage {
-                role: role.to_string(),
+                role,
                 content: blocks,
             });
         }
@@ -321,9 +320,16 @@ enum AnthropicSystemBlock {
     Text { text: String },
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum AnthropicRole {
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 struct AnthropicMessage {
-    role: String,
+    role: AnthropicRole,
     content: Vec<AnthropicContentBlock>,
 }
 
@@ -347,12 +353,11 @@ enum AnthropicContentBlock {
     },
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct AnthropicImageSource {
-    #[serde(rename = "type")]
-    source_type: String,
-    media_type: String,
-    data: String,
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AnthropicImageSource {
+    Base64 { media_type: String, data: String },
+    Url { url: String },
 }
 
 #[derive(Debug, Serialize)]
@@ -441,5 +446,202 @@ mod tests {
             .test_connection("test-model")
             .await
             .expect("test connection should succeed");
+    }
+
+    // Tests for AnthropicImageSource with base64 and url types
+    #[test]
+    fn test_base64_image_source_serde() {
+        let source = AnthropicImageSource::Base64 {
+            media_type: "image/jpeg".to_string(),
+            data: "base64encodeddata".to_string(),
+        };
+        let json_value = serde_json::to_value(&source).expect("serialize base64 source");
+        assert_eq!(
+            json_value,
+            json!({
+                "type": "base64",
+                "media_type": "image/jpeg",
+                "data": "base64encodeddata"
+            })
+        );
+
+        // Test deserialization
+        let deserialized: AnthropicImageSource =
+            serde_json::from_value(json_value).expect("deserialize base64 source");
+        match deserialized {
+            AnthropicImageSource::Base64 { media_type, data } => {
+                assert_eq!(media_type, "image/jpeg");
+                assert_eq!(data, "base64encodeddata");
+            }
+            _ => panic!("expected Base64 variant"),
+        }
+    }
+
+    #[test]
+    fn test_url_image_source_serde() {
+        let source = AnthropicImageSource::Url {
+            url: "https://example.com/image.png".to_string(),
+        };
+        let json_value = serde_json::to_value(&source).expect("serialize url source");
+        assert_eq!(
+            json_value,
+            json!({
+                "type": "url",
+                "url": "https://example.com/image.png"
+            })
+        );
+
+        // Test deserialization
+        let deserialized: AnthropicImageSource =
+            serde_json::from_value(json_value).expect("deserialize url source");
+        match deserialized {
+            AnthropicImageSource::Url { url } => {
+                assert_eq!(url, "https://example.com/image.png");
+            }
+            _ => panic!("expected Url variant"),
+        }
+    }
+
+    #[test]
+    fn test_anthropic_message_role_serde() {
+        // Test User role
+        let user_msg = AnthropicMessage {
+            role: AnthropicRole::User,
+            content: vec![AnthropicContentBlock::Text {
+                text: "hello".to_string(),
+            }],
+        };
+        let json_value = serde_json::to_value(&user_msg).expect("serialize user message");
+        assert_eq!(
+            json_value,
+            json!({
+                "role": "user",
+                "content": [{"type": "text", "text": "hello"}]
+            })
+        );
+
+        // Test Assistant role
+        let assistant_msg = AnthropicMessage {
+            role: AnthropicRole::Assistant,
+            content: vec![AnthropicContentBlock::Text {
+                text: "hi".to_string(),
+            }],
+        };
+        let json_value = serde_json::to_value(&assistant_msg).expect("serialize assistant message");
+        assert_eq!(
+            json_value,
+            json!({
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hi"}]
+            })
+        );
+
+        // Test deserialization
+        let deserialized: AnthropicMessage =
+            serde_json::from_value(json_value).expect("deserialize message");
+        assert!(matches!(deserialized.role, AnthropicRole::Assistant));
+    }
+
+    #[test]
+    fn test_image_content_block_with_base64_source() {
+        let block = AnthropicContentBlock::Image {
+            source: AnthropicImageSource::Base64 {
+                media_type: "image/png".to_string(),
+                data: "pngdata".to_string(),
+            },
+        };
+        let json_value = serde_json::to_value(&block).expect("serialize image block");
+        assert_eq!(
+            json_value,
+            json!({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "pngdata"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_image_content_block_with_url_source() {
+        let block = AnthropicContentBlock::Image {
+            source: AnthropicImageSource::Url {
+                url: "https://example.com/photo.jpg".to_string(),
+            },
+        };
+        let json_value = serde_json::to_value(&block).expect("serialize image block");
+        assert_eq!(
+            json_value,
+            json!({
+                "type": "image",
+                "source": {
+                    "type": "url",
+                    "url": "https://example.com/photo.jpg"
+                }
+            })
+        );
+    }
+
+    // Regression test: ensure message/image block output matches Anthropic API expectations
+    #[test]
+    fn test_request_body_serialization_with_image_and_role() {
+        let request = AnthropicRequest {
+            model: "claude-3-opus-20240229".to_string(),
+            max_tokens: 1024,
+            system: None,
+            messages: vec![
+                AnthropicMessage {
+                    role: AnthropicRole::User,
+                    content: vec![
+                        AnthropicContentBlock::Text {
+                            text: "Describe this image".to_string(),
+                        },
+                        AnthropicContentBlock::Image {
+                            source: AnthropicImageSource::Url {
+                                url: "https://example.com/image.jpg".to_string(),
+                            },
+                        },
+                    ],
+                },
+                AnthropicMessage {
+                    role: AnthropicRole::Assistant,
+                    content: vec![AnthropicContentBlock::Text {
+                        text: "I see...".to_string(),
+                    }],
+                },
+            ],
+            tools: None,
+        };
+
+        let json_value = serde_json::to_value(&request).expect("serialize request");
+        let expected = json!({
+            "model": "claude-3-opus-20240229",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this image"},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "url",
+                                "url": "https://example.com/image.jpg"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "I see..."}
+                    ]
+                }
+            ]
+        });
+
+        assert_eq!(json_value, expected);
     }
 }

--- a/src/provider/anthropic_compatible.rs
+++ b/src/provider/anthropic_compatible.rs
@@ -45,17 +45,12 @@ impl AnthropicCompatibleProvider {
     fn format_content_block(&self, content: &Content) -> BabataResult<AnthropicContentBlock> {
         match content {
             Content::Text { text } => Ok(AnthropicContentBlock::Text { text: text.clone() }),
-            Content::ImageUrl { .. } => {
-                warn!(
-                    "Anthropic-compatible API does not support image URL source, only base64 - skipping image content"
-                );
-                Err(BabataError::provider(
-                    "Anthropic-compatible API does not support image URL source, only base64",
-                ))
-            }
+            Content::ImageUrl { url } => Ok(AnthropicContentBlock::Image {
+                source: AnthropicImageSource::Url { url: url.clone() },
+            }),
             Content::ImageData { data, media_type } => Ok(AnthropicContentBlock::Image {
                 source: AnthropicImageSource::Base64 {
-                    media_type: media_type.as_mime_str(),
+                    media_type: *media_type,
                     data: data.clone(),
                 },
             }),
@@ -356,8 +351,13 @@ enum AnthropicContentBlock {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum AnthropicImageSource {
-    Base64 { media_type: String, data: String },
-    Url { url: String },
+    Base64 {
+        media_type: crate::message::MediaType,
+        data: String,
+    },
+    Url {
+        url: String,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -451,8 +451,10 @@ mod tests {
     // Tests for AnthropicImageSource with base64 and url types
     #[test]
     fn test_base64_image_source_serde() {
+        use crate::message::MediaType;
+
         let source = AnthropicImageSource::Base64 {
-            media_type: "image/jpeg".to_string(),
+            media_type: MediaType::ImageJpeg,
             data: "base64encodeddata".to_string(),
         };
         let json_value = serde_json::to_value(&source).expect("serialize base64 source");
@@ -470,7 +472,7 @@ mod tests {
             serde_json::from_value(json_value).expect("deserialize base64 source");
         match deserialized {
             AnthropicImageSource::Base64 { media_type, data } => {
-                assert_eq!(media_type, "image/jpeg");
+                assert_eq!(media_type, MediaType::ImageJpeg);
                 assert_eq!(data, "base64encodeddata");
             }
             _ => panic!("expected Base64 variant"),
@@ -544,9 +546,11 @@ mod tests {
 
     #[test]
     fn test_image_content_block_with_base64_source() {
+        use crate::message::MediaType;
+
         let block = AnthropicContentBlock::Image {
             source: AnthropicImageSource::Base64 {
-                media_type: "image/png".to_string(),
+                media_type: MediaType::ImagePng,
                 data: "pngdata".to_string(),
             },
         };
@@ -642,6 +646,103 @@ mod tests {
             ]
         });
 
+        assert_eq!(json_value, expected);
+    }
+
+    // Regression test: ensure Content::ImageUrl is correctly mapped to AnthropicImageSource::Url
+    #[test]
+    fn test_format_content_block_maps_image_url_to_anthropic_url_source() {
+        let provider = AnthropicCompatibleProvider::new("test-key", "http://localhost");
+        let content = Content::ImageUrl {
+            url: "https://example.com/image.jpg".to_string(),
+        };
+        let block = provider
+            .format_content_block(&content)
+            .expect("should map image URL");
+        match block {
+            AnthropicContentBlock::Image {
+                source: AnthropicImageSource::Url { url },
+            } => {
+                assert_eq!(url, "https://example.com/image.jpg");
+            }
+            other => panic!("expected Image block with Url source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_format_content_block_maps_image_data_to_anthropic_base64_source() {
+        use crate::message::MediaType;
+
+        let provider = AnthropicCompatibleProvider::new("test-key", "http://localhost");
+        let content = Content::ImageData {
+            data: "base64data".to_string(),
+            media_type: MediaType::ImageWebp,
+        };
+        let block = provider
+            .format_content_block(&content)
+            .expect("should map image data");
+        match block {
+            AnthropicContentBlock::Image {
+                source: AnthropicImageSource::Base64 { media_type, data },
+            } => {
+                assert_eq!(media_type, MediaType::ImageWebp);
+                assert_eq!(data, "base64data");
+            }
+            other => panic!("expected Image block with Base64 source, got {other:?}"),
+        }
+    }
+
+    // Regression test: ensure a full UserPrompt with ImageUrl serializes correctly
+    #[test]
+    fn test_format_messages_with_image_url_content() {
+        use crate::message::MediaType;
+
+        let provider = AnthropicCompatibleProvider::new("test-key", "http://localhost");
+        let messages = vec![Message::UserPrompt {
+            content: vec![
+                Content::Text {
+                    text: "What's in this image?".to_string(),
+                },
+                Content::ImageUrl {
+                    url: "https://cdn.example.com/photo.png".to_string(),
+                },
+                Content::ImageData {
+                    data: "abc123".to_string(),
+                    media_type: MediaType::ImagePng,
+                },
+            ],
+            created_at: chrono::Utc::now(),
+        }];
+        let anthropic_messages = provider
+            .format_messages(&messages)
+            .expect("format messages");
+        assert_eq!(anthropic_messages.len(), 1);
+        assert_eq!(anthropic_messages[0].role, AnthropicRole::User);
+        assert_eq!(anthropic_messages[0].content.len(), 3);
+
+        // Verify serialization produces correct JSON
+        let json_value = serde_json::to_value(&anthropic_messages[0]).expect("serialize message");
+        let expected = json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "url",
+                        "url": "https://cdn.example.com/photo.png"
+                    }
+                },
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "abc123"
+                    }
+                }
+            ]
+        });
         assert_eq!(json_value, expected);
     }
 }


### PR DESCRIPTION
## Background / Goal

This PR improves the Anthropic-compatible provider to properly support URL-based image sources and introduces stronger typing for the Anthropic API request/response models.

## Main Changes

1. **Typed `AnthropicRole` enum**
   - Replaces raw `String` with a strongly-typed `AnthropicRole` enum (`User`, `Assistant`).
   - Eliminates invalid role values at compile time.

2. **Refactored `AnthropicImageSource`**
   - Transforms the flat `AnthropicImageSource` struct into an enum with two variants:
     - `Base64 { media_type, data }` — for inline base64-encoded images
     - `Url { url }` — for externally hosted images
   - This aligns with the current Anthropic Messages API which supports both `"type": "base64"` and `"type": "url"` image sources.

3. **`Content::ImageUrl` now maps correctly**
   - `format_content_block` maps `Content::ImageUrl` to `AnthropicImageSource::Url` instead of returning an error.
   - Fixes a regression where URL images were incorrectly rejected.

4. **Tightened `media_type` type**
   - `AnthropicImageSource::Base64.media_type` changed from `String` to `MediaType`.
   - Invalid MIME values become unrepresentable at the type level.

5. **New regression tests**
   - `test_format_content_block_maps_image_url_to_anthropic_url_source`
   - `test_format_content_block_maps_image_data_to_anthropic_base64_source`
   - `test_format_messages_with_image_url_content`

## Validation Results

| Command | Result |
|---------|--------|
| `cargo fmt --check` | ✅ Pass |
| `cargo clippy --all-targets --all-features` | ✅ Pass (0 warnings) |
| `cargo test` | ✅ Pass (182 tests) |

## Related

- Review round 1 branch: `feat/anthropic-image-source-types` (commit `c1a4a48`)
