### PR TITLE
refactor(message): introduce AssistantThinking variant and remove reasoning_content from other variants

### DIFF
--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -12,7 +12,7 @@ use crate::{
     error::BabataError,
     memory::Memory,
     message::{Content, Message},
-    provider::{GenerationRequest, Provider, ProviderConfig, create_provider},
+    provider::{GenerationRequest, GenerationResponse, Provider, ProviderConfig, create_provider},
     skill::load_skills,
     system_prompt::build_system_prompts,
     task::SteerQueue,
@@ -83,7 +83,7 @@ impl AgentTask {
                     conversation.push(steer_message);
                 }
             }
-            let message = generate_with_retry(
+            let response = generate_with_retry(
                 provider.as_ref(),
                 self.task_id,
                 &model,
@@ -93,7 +93,20 @@ impl AgentTask {
                 &tool_specs,
             )
             .await?;
-            crate::task_info!(self.task_id, "Provider returned message: {:?}", message);
+            crate::task_info!(
+                self.task_id,
+                "Provider returned message: {:?}, thinking: {:?}",
+                response.message,
+                response.thinking
+            );
+
+            if let Some(thinking) = response.thinking {
+                self.memory
+                    .append_messages(self.task_id, std::slice::from_ref(&thinking))?;
+                conversation.push(thinking);
+            }
+
+            let message = response.message;
             self.memory
                 .append_messages(self.task_id, std::slice::from_ref(&message))?;
             conversation.push(message.clone());
@@ -143,6 +156,11 @@ impl AgentTask {
                     self.memory.append_messages(self.task_id, &results)?;
                     conversation.extend(results);
                 }
+                Message::AssistantThinking { .. } => {
+                    return Err(BabataError::provider(
+                        "Provider returned AssistantThinking as primary message",
+                    ));
+                }
                 Message::UserPrompt { .. }
                 | Message::UserSteering { .. }
                 | Message::ToolResult { .. } => {
@@ -186,7 +204,7 @@ async fn generate_with_retry(
     prompts: &[Message],
     context: &str,
     tool_specs: &[ToolSpec],
-) -> BabataResult<Message> {
+) -> BabataResult<GenerationResponse> {
     let backoff = ExponentialBuilder::default()
         .with_min_delay(Duration::from_millis(PROVIDER_RETRY_MIN_DELAY_MS))
         .with_max_delay(Duration::from_secs(PROVIDER_RETRY_MAX_DELAY_SECS))
@@ -203,7 +221,7 @@ async fn generate_with_retry(
                 tools: tool_specs,
             })
             .await?;
-        Ok(response.message)
+        Ok(response)
     })
     .retry(backoff)
     .when(|err| matches!(err, BabataError::Provider(_, _)))

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -100,13 +100,22 @@ impl AgentTask {
                 response.thinking
             );
 
+            let message = response.message;
+
+            // Guard: provider must not return AssistantThinking as the primary message.
+            // Reject before any persistence to avoid dirty data.
+            if matches!(message, Message::AssistantThinking { .. }) {
+                return Err(BabataError::provider(
+                    "Provider returned AssistantThinking as primary message",
+                ));
+            }
+
             if let Some(thinking) = response.thinking {
                 self.memory
                     .append_messages(self.task_id, std::slice::from_ref(&thinking))?;
                 conversation.push(thinking);
             }
 
-            let message = response.message;
             self.memory
                 .append_messages(self.task_id, std::slice::from_ref(&message))?;
             conversation.push(message.clone());

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -88,13 +88,18 @@ This file stores important information that should persist across sessions.
     }
 
     fn render_context(messages: &[Message]) -> String {
-        if messages.is_empty() {
+        let filtered: Vec<&Message> = messages
+            .iter()
+            .filter(|m| !matches!(m, Message::AssistantThinking { .. }))
+            .collect();
+
+        if filtered.is_empty() {
             return String::new();
         }
 
-        let mut sections = Vec::with_capacity(messages.len() + 1);
+        let mut sections = Vec::with_capacity(filtered.len() + 1);
         sections.push("## Conversation History".to_string());
-        for message in messages {
+        for message in filtered {
             sections.push(Self::render_message(message));
         }
         sections.join("\n\n")
@@ -108,38 +113,21 @@ This file stores important information that should persist across sessions.
             Message::UserSteering { content, .. } => {
                 format!("[steer]\n{}", Self::render_content(content))
             }
-            Message::AssistantResponse {
-                content,
-                reasoning_content,
-                ..
-            } => {
-                let mut lines = Vec::new();
-                lines.push("[assistant]".to_string());
-                if let Some(reasoning_content) = reasoning_content
-                    && !reasoning_content.trim().is_empty()
-                {
-                    lines.push(format!("Reasoning:\n{}", reasoning_content.trim()));
-                }
-                lines.push(Self::render_content(content));
-                lines.join("\n")
+            Message::AssistantResponse { content, .. } => {
+                ["[assistant]".to_string(), Self::render_content(content)].join("\n")
             }
-            Message::AssistantToolCalls {
-                calls,
-                reasoning_content,
-                ..
-            } => {
+            Message::AssistantToolCalls { calls, .. } => {
                 let mut lines = Vec::new();
                 lines.push("[assistant_tool_calls]".to_string());
-                if let Some(reasoning_content) = reasoning_content
-                    && !reasoning_content.trim().is_empty()
-                {
-                    lines.push(format!("Reasoning:\n{}", reasoning_content.trim()));
-                }
                 for call in calls {
                     lines.push(format!("Tool: {}", call.tool_name));
                     lines.push(format!("Args: {}", call.args));
                 }
                 lines.join("\n")
+            }
+            Message::AssistantThinking { .. } => {
+                // AssistantThinking is filtered out of context, but handle it here for completeness.
+                String::new()
             }
             Message::ToolResult { call, result, .. } => {
                 format!(
@@ -264,7 +252,6 @@ mod tests {
                         content: vec![Content::Text {
                             text: "world".to_string(),
                         }],
-                        reasoning_content: None,
                         created_at: now,
                     },
                 ],

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -267,4 +267,49 @@ mod tests {
         assert!(context.contains("[user]\nhello"));
         assert!(context.contains("[assistant]\nworld"));
     }
+
+    #[test]
+    fn render_context_filters_out_assistant_thinking() {
+        let messages = vec![
+            Message::UserPrompt {
+                content: vec![Content::Text {
+                    text: "hello".to_string(),
+                }],
+                created_at: Utc::now(),
+            },
+            Message::AssistantThinking {
+                content: "thinking...".to_string(),
+                signature: None,
+                created_at: Utc::now(),
+            },
+            Message::AssistantResponse {
+                content: vec![Content::Text {
+                    text: "world".to_string(),
+                }],
+                created_at: Utc::now(),
+            },
+        ];
+
+        let context = Memory::render_context(&messages);
+        assert!(context.contains("[user]\nhello"));
+        assert!(context.contains("[assistant]\nworld"));
+        assert!(!context.contains("thinking"));
+    }
+
+    #[test]
+    fn assistant_thinking_serde_roundtrip() {
+        let message = Message::AssistantThinking {
+            content: "I need to calculate...".to_string(),
+            signature: Some("sig-xyz".to_string()),
+            created_at: Utc::now(),
+        };
+
+        let json = serde_json::to_string(&message).expect("serialize");
+        assert!(json.contains("\"type\":\"assistant_thinking\""));
+        assert!(json.contains("\"content\":\"I need to calculate...\""));
+        assert!(json.contains("\"signature\":\"sig-xyz\""));
+
+        let deserialized: Message = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(message, deserialized);
+    }
 }

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -22,7 +22,7 @@ pub struct MessageRecord {
     pub message_type: MessageType,
     #[serde(with = "option_json_string")]
     pub content: Option<Vec<Content>>,
-    pub reasoning_content: Option<String>,
+    pub signature: Option<String>,
     #[serde(with = "option_json_string")]
     pub tool_calls: Option<Vec<ToolCall>>,
     pub result: Option<String>,
@@ -98,6 +98,7 @@ pub enum MessageType {
     UserSteering,
     AssistantResponse,
     AssistantToolCalls,
+    AssistantThinking,
     ToolResult,
 }
 
@@ -108,6 +109,7 @@ impl fmt::Display for MessageType {
             MessageType::UserSteering => "user_steering",
             MessageType::AssistantResponse => "assistant_response",
             MessageType::AssistantToolCalls => "assistant_tool_calls",
+            MessageType::AssistantThinking => "assistant_thinking",
             MessageType::ToolResult => "tool_result",
         };
         write!(f, "{}", s)
@@ -123,6 +125,7 @@ impl FromStr for MessageType {
             "user_steering" => Ok(MessageType::UserSteering),
             "assistant_response" => Ok(MessageType::AssistantResponse),
             "assistant_tool_calls" => Ok(MessageType::AssistantToolCalls),
+            "assistant_thinking" => Ok(MessageType::AssistantThinking),
             "tool_result" => Ok(MessageType::ToolResult),
             _ => Err(BabataError::memory(format!("Unknown message type: {}", s))),
         }
@@ -177,7 +180,7 @@ impl MessageStore {
                 task_id TEXT NOT NULL,
                 message_type TEXT NOT NULL,
                 content TEXT,
-                reasoning_content TEXT,
+                signature TEXT,
                 tool_calls TEXT,
                 result TEXT,
                 created_at TEXT NOT NULL
@@ -210,7 +213,7 @@ impl MessageStore {
                 task_id,
                 message_type: MessageType::UserPrompt,
                 content: Some(c.clone()),
-                reasoning_content: None,
+                signature: None,
                 tool_calls: None,
                 result: None,
                 created_at,
@@ -219,34 +222,39 @@ impl MessageStore {
                 task_id,
                 message_type: MessageType::UserSteering,
                 content: Some(c.clone()),
-                reasoning_content: None,
+                signature: None,
                 tool_calls: None,
                 result: None,
                 created_at,
             },
-            Message::AssistantResponse {
-                content: c,
-                reasoning_content: r,
-                ..
-            } => MessageRecord {
+            Message::AssistantResponse { content: c, .. } => MessageRecord {
                 task_id,
                 message_type: MessageType::AssistantResponse,
                 content: Some(c.clone()),
-                reasoning_content: r.clone(),
+                signature: None,
                 tool_calls: None,
                 result: None,
                 created_at,
             },
-            Message::AssistantToolCalls {
-                calls,
-                reasoning_content: r,
-                ..
-            } => MessageRecord {
+            Message::AssistantToolCalls { calls, .. } => MessageRecord {
                 task_id,
                 message_type: MessageType::AssistantToolCalls,
                 content: None,
-                reasoning_content: r.clone(),
+                signature: None,
                 tool_calls: Some(calls.clone()),
+                result: None,
+                created_at,
+            },
+            Message::AssistantThinking {
+                content, signature, ..
+            } => MessageRecord {
+                task_id,
+                message_type: MessageType::AssistantThinking,
+                content: Some(vec![Content::Text {
+                    text: content.clone(),
+                }]),
+                signature: signature.clone(),
+                tool_calls: None,
                 result: None,
                 created_at,
             },
@@ -256,7 +264,7 @@ impl MessageStore {
                 task_id,
                 message_type: MessageType::ToolResult,
                 content: None,
-                reasoning_content: None,
+                signature: None,
                 tool_calls: Some(vec![call.clone()]),
                 result: Some(res.clone()),
                 created_at,
@@ -289,15 +297,26 @@ impl MessageStore {
                 let content = record.content.clone().unwrap_or_default();
                 Message::AssistantResponse {
                     content,
-                    reasoning_content: record.reasoning_content.clone(),
                     created_at,
                 }
             }
             MessageType::AssistantToolCalls => {
                 let calls = record.tool_calls.clone().unwrap_or_default();
-                Message::AssistantToolCalls {
-                    calls,
-                    reasoning_content: record.reasoning_content.clone(),
+                Message::AssistantToolCalls { calls, created_at }
+            }
+            MessageType::AssistantThinking => {
+                let text = record
+                    .content
+                    .as_ref()
+                    .and_then(|c| c.first())
+                    .map(|c| match c {
+                        Content::Text { text } => text.clone(),
+                        _ => String::new(),
+                    })
+                    .unwrap_or_default();
+                Message::AssistantThinking {
+                    content: text,
+                    signature: record.signature.clone(),
                     created_at,
                 }
             }
@@ -330,7 +349,7 @@ impl MessageStore {
 
         let conn = self.connect()?;
         let mut stmt = conn
-            .prepare("INSERT INTO messages (task_id, message_type, content, reasoning_content, tool_calls, result, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)")
+            .prepare("INSERT INTO messages (task_id, message_type, content, signature, tool_calls, result, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)")
             .map_err(|err| {
                 BabataError::memory(format!(
                     "Failed to prepare message insert statement: {}",
@@ -365,7 +384,7 @@ impl MessageStore {
                 record.task_id.to_string(),
                 message_type_str,
                 content_json,
-                record.reasoning_content,
+                record.signature,
                 tool_calls_json,
                 record.result,
                 record.created_at.to_rfc3339()
@@ -386,7 +405,8 @@ impl MessageStore {
             return Ok(Vec::new());
         }
 
-        let query = "SELECT task_id, message_type, content, reasoning_content, tool_calls, result, created_at
+        let query =
+            "SELECT task_id, message_type, content, signature, tool_calls, result, created_at
             FROM messages
             WHERE task_id = ?1
             ORDER BY datetime(created_at), rowid
@@ -432,11 +452,8 @@ impl MessageStore {
             let content_json: Option<String> = row.get(2).map_err(|err| {
                 BabataError::memory(format!("Failed to read content from row: {}", err))
             })?;
-            let reasoning_content: Option<String> = row.get(3).map_err(|err| {
-                BabataError::memory(format!(
-                    "Failed to read reasoning_content from row: {}",
-                    err
-                ))
+            let signature: Option<String> = row.get(3).map_err(|err| {
+                BabataError::memory(format!("Failed to read signature from row: {}", err))
             })?;
             let tool_calls_json: Option<String> = row.get(4).map_err(|err| {
                 BabataError::memory(format!("Failed to read tool_calls from row: {}", err))
@@ -476,7 +493,7 @@ impl MessageStore {
                 task_id,
                 message_type,
                 content,
-                reasoning_content,
+                signature,
                 tool_calls,
                 result,
                 created_at,
@@ -494,8 +511,8 @@ impl MessageStore {
         }
 
         let query =
-            "SELECT task_id, message_type, content, reasoning_content, tool_calls, result, created_at FROM (
-            SELECT task_id, message_type, content, reasoning_content, tool_calls, result, created_at, rowid
+            "SELECT task_id, message_type, content, signature, tool_calls, result, created_at FROM (
+            SELECT task_id, message_type, content, signature, tool_calls, result, created_at, rowid
             FROM messages
             ORDER BY datetime(created_at) DESC, rowid DESC
             LIMIT ?1
@@ -532,11 +549,8 @@ impl MessageStore {
             let content_json: Option<String> = row.get(2).map_err(|err| {
                 BabataError::memory(format!("Failed to read content from row: {}", err))
             })?;
-            let reasoning_content: Option<String> = row.get(3).map_err(|err| {
-                BabataError::memory(format!(
-                    "Failed to read reasoning_content from row: {}",
-                    err
-                ))
+            let signature: Option<String> = row.get(3).map_err(|err| {
+                BabataError::memory(format!("Failed to read signature from row: {}", err))
             })?;
             let tool_calls_json: Option<String> = row.get(4).map_err(|err| {
                 BabataError::memory(format!("Failed to read tool_calls from row: {}", err))
@@ -579,7 +593,7 @@ impl MessageStore {
                 task_id,
                 message_type,
                 content,
-                reasoning_content,
+                signature,
                 tool_calls,
                 result,
                 created_at,
@@ -672,7 +686,6 @@ mod tests {
                     tool_name: "read_file".to_string(),
                     args: r#"{"path": "README.md"}"#.to_string(),
                 }],
-                reasoning_content: None,
                 created_at: now,
             },
             Message::ToolResult {
@@ -694,7 +707,6 @@ mod tests {
                         media_type: MediaType::ImagePng,
                     },
                 ],
-                reasoning_content: None,
                 created_at: now,
             },
         ];
@@ -791,7 +803,6 @@ mod tests {
                         content: vec![Content::Text {
                             text: "m3".to_string(),
                         }],
-                        reasoning_content: None,
                         created_at: now + chrono::Duration::seconds(2),
                     },
                 ],

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -191,17 +191,6 @@ impl MessageStore {
             BabataError::memory(format!("Failed to initialize messages table: {}", err))
         })?;
 
-        // Idempotent migration: old databases may lack the `signature` column.
-        if let Err(e) = conn.execute("ALTER TABLE messages ADD COLUMN signature TEXT", []) {
-            let err_msg = e.to_string();
-            if !err_msg.contains("duplicate column name") {
-                return Err(BabataError::memory(format!(
-                    "Failed to migrate messages table schema: {}",
-                    e
-                )));
-            }
-        }
-
         Ok(Self { db_path })
     }
 

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -191,6 +191,17 @@ impl MessageStore {
             BabataError::memory(format!("Failed to initialize messages table: {}", err))
         })?;
 
+        // Idempotent migration: old databases may lack the `signature` column.
+        if let Err(e) = conn.execute("ALTER TABLE messages ADD COLUMN signature TEXT", []) {
+            let err_msg = e.to_string();
+            if !err_msg.contains("duplicate column name") {
+                return Err(BabataError::memory(format!(
+                    "Failed to migrate messages table schema: {}",
+                    e
+                )));
+            }
+        }
+
         Ok(Self { db_path })
     }
 
@@ -686,6 +697,11 @@ mod tests {
                     tool_name: "read_file".to_string(),
                     args: r#"{"path": "README.md"}"#.to_string(),
                 }],
+                created_at: now,
+            },
+            Message::AssistantThinking {
+                content: "Let me think...".to_string(),
+                signature: Some("sig-abc".to_string()),
                 created_at: now,
             },
             Message::ToolResult {

--- a/src/message.rs
+++ b/src/message.rs
@@ -14,12 +14,15 @@ pub enum Message {
     },
     AssistantResponse {
         content: Vec<Content>,
-        reasoning_content: Option<String>,
         created_at: DateTime<Utc>,
     },
     AssistantToolCalls {
         calls: Vec<ToolCall>,
-        reasoning_content: Option<String>,
+        created_at: DateTime<Utc>,
+    },
+    AssistantThinking {
+        content: String,
+        signature: Option<String>,
         created_at: DateTime<Utc>,
     },
     ToolResult {
@@ -36,6 +39,7 @@ impl Message {
             Message::UserSteering { created_at, .. } => created_at,
             Message::AssistantResponse { created_at, .. } => created_at,
             Message::AssistantToolCalls { created_at, .. } => created_at,
+            Message::AssistantThinking { created_at, .. } => created_at,
             Message::ToolResult { created_at, .. } => created_at,
         }
     }

--- a/src/provider/anthropic_compatible.rs
+++ b/src/provider/anthropic_compatible.rs
@@ -86,16 +86,17 @@ impl AnthropicCompatibleProvider {
                 Message::AssistantThinking {
                     content, signature, ..
                 } => {
-                    // The generic Message model does not store provider-specific signatures.
-                    // Therefore we send an empty signature when none is present. This is a design
-                    // boundary: round-tripping a thinking block through the generic Message model
-                    // may lose the original signature, and the provider may reject it on subsequent
-                    // turns. A provider-specific storage layer would be needed to preserve
-                    // signatures across turns.
-                    let sig = signature.clone().unwrap_or_default();
+                    let sig = signature.as_deref().unwrap_or("").trim();
+                    if sig.is_empty() {
+                        warn!(
+                            "Skipping AssistantThinking message with empty or missing signature: {}",
+                            content
+                        );
+                        continue;
+                    }
                     let blocks = vec![AnthropicContentBlock::Thinking {
                         thinking: content.clone(),
-                        signature: sig,
+                        signature: sig.to_string(),
                     }];
                     (AnthropicRole::Assistant, blocks)
                 }
@@ -175,18 +176,32 @@ impl AnthropicCompatibleProvider {
                         args,
                     });
                 }
-                AnthropicContentBlock::Thinking { thinking, .. } => {
-                    thinking_parts.push(thinking);
+                AnthropicContentBlock::Thinking {
+                    thinking,
+                    signature,
+                } => {
+                    let sig = signature.trim();
+                    if sig.is_empty() {
+                        return Err(BabataError::provider(
+                            "Anthropic thinking block has empty or missing signature",
+                        ));
+                    }
+                    thinking_parts.push((thinking, sig.to_string()));
                 }
                 _ => {}
             }
         }
 
         let thinking = if !thinking_parts.is_empty() {
-            let content = thinking_parts.join("\n");
+            let content = thinking_parts
+                .iter()
+                .map(|(thinking, _)| thinking.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            let signature = thinking_parts.first().map(|(_, sig)| sig.clone());
             Some(Message::AssistantThinking {
                 content,
-                signature: None,
+                signature,
                 created_at: Utc::now(),
             })
         } else {
@@ -503,7 +518,7 @@ mod tests {
         let provider = AnthropicCompatibleProvider::new("test-key", "http://localhost");
         let messages = vec![Message::AssistantThinking {
             content: "I need to calculate...".to_string(),
-            signature: None,
+            signature: Some("sig-abc".to_string()),
             created_at: chrono::Utc::now(),
         }];
         let anthropic_messages = provider
@@ -519,9 +534,47 @@ mod tests {
                 signature,
             } => {
                 assert_eq!(thinking, "I need to calculate...");
-                assert!(signature.is_empty());
+                assert_eq!(signature, "sig-abc");
             }
             other => panic!("expected Thinking block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_format_messages_skips_empty_signature_thinking() {
+        let provider = AnthropicCompatibleProvider::new("test-key", "http://localhost");
+        let messages = vec![
+            Message::AssistantThinking {
+                content: "No signature here.".to_string(),
+                signature: None,
+                created_at: chrono::Utc::now(),
+            },
+            Message::AssistantThinking {
+                content: "Empty signature.".to_string(),
+                signature: Some("".to_string()),
+                created_at: chrono::Utc::now(),
+            },
+            Message::AssistantThinking {
+                content: "Whitespace signature.".to_string(),
+                signature: Some("   ".to_string()),
+                created_at: chrono::Utc::now(),
+            },
+            Message::AssistantResponse {
+                content: vec![Content::Text {
+                    text: "Final answer.".to_string(),
+                }],
+                created_at: chrono::Utc::now(),
+            },
+        ];
+        let anthropic_messages = provider
+            .format_messages(&messages)
+            .expect("format messages");
+        assert_eq!(anthropic_messages.len(), 1);
+        assert_eq!(anthropic_messages[0].role, AnthropicRole::Assistant);
+        assert_eq!(anthropic_messages[0].content.len(), 1);
+        match &anthropic_messages[0].content[0] {
+            AnthropicContentBlock::Text { text } => assert_eq!(text, "Final answer."),
+            other => panic!("expected Text block, got {other:?}"),
         }
     }
 
@@ -610,9 +663,43 @@ mod tests {
                 content, signature, ..
             } => {
                 assert_eq!(content, "Let me analyze this...");
-                assert_eq!(signature, None);
+                assert_eq!(signature, Some("sig-xyz".to_string()));
             }
             other => panic!("expected AssistantThinking, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_response_parsing_rejects_empty_signature_thinking() {
+        let provider = AnthropicCompatibleProvider::new("test-key", "http://localhost");
+        let response_body = AnthropicResponse {
+            id: "msg-1".to_string(),
+            response_type: "message".to_string(),
+            role: "assistant".to_string(),
+            content: vec![
+                AnthropicContentBlock::Thinking {
+                    thinking: "Let me analyze this...".to_string(),
+                    signature: "".to_string(),
+                },
+                AnthropicContentBlock::Text {
+                    text: "Here is my analysis.".to_string(),
+                },
+            ],
+            model: "claude-3-7-sonnet".to_string(),
+            stop_reason: Some("end_turn".to_string()),
+        };
+
+        let result = provider.parse_response(response_body);
+        match result {
+            Ok(_) => panic!("expected error for empty signature thinking block"),
+            Err(e) => {
+                let err_msg = format!("{}", e);
+                assert!(
+                    err_msg.contains("empty or missing signature"),
+                    "Expected error about empty signature, got: {}",
+                    err_msg
+                );
+            }
         }
     }
 
@@ -654,8 +741,11 @@ mod tests {
         }
         let thinking = response.thinking.expect("should have thinking");
         match thinking {
-            Message::AssistantThinking { content, .. } => {
+            Message::AssistantThinking {
+                content, signature, ..
+            } => {
                 assert_eq!(content, "I need to search.");
+                assert_eq!(signature, Some("sig-abc".to_string()));
             }
             other => panic!("expected AssistantThinking, got {other:?}"),
         }

--- a/src/provider/anthropic_compatible.rs
+++ b/src/provider/anthropic_compatible.rs
@@ -83,53 +83,39 @@ impl AnthropicCompatibleProvider {
                     }
                     (AnthropicRole::User, blocks)
                 }
-                Message::AssistantToolCalls {
-                    calls,
-                    reasoning_content,
-                    ..
+                Message::AssistantThinking {
+                    content, signature, ..
                 } => {
-                    let mut blocks = Vec::new();
-                    if let Some(rc) = reasoning_content {
-                        // The generic Message model does not store provider-specific signatures.
-                        // Therefore we send an empty signature here. This is a design boundary:
-                        // round-tripping a thinking block through the generic Message model will
-                        // lose the original signature, and the provider may reject it on
-                        // subsequent turns. A provider-specific storage layer would be needed
-                        // to preserve signatures across turns.
-                        blocks.push(AnthropicContentBlock::Thinking {
-                            thinking: rc.clone(),
-                            signature: String::new(),
-                        });
-                    }
-                    blocks.extend(calls.iter().map(|call| {
-                        let input: Value = serde_json::from_str(&call.args)
-                            .unwrap_or_else(|_| Value::Object(Default::default()));
-                        AnthropicContentBlock::ToolUse {
-                            id: call.call_id.clone(),
-                            name: call.tool_name.clone(),
-                            input,
-                        }
-                    }));
+                    // The generic Message model does not store provider-specific signatures.
+                    // Therefore we send an empty signature when none is present. This is a design
+                    // boundary: round-tripping a thinking block through the generic Message model
+                    // may lose the original signature, and the provider may reject it on subsequent
+                    // turns. A provider-specific storage layer would be needed to preserve
+                    // signatures across turns.
+                    let sig = signature.clone().unwrap_or_default();
+                    let blocks = vec![AnthropicContentBlock::Thinking {
+                        thinking: content.clone(),
+                        signature: sig,
+                    }];
                     (AnthropicRole::Assistant, blocks)
                 }
-                Message::AssistantResponse {
-                    content,
-                    reasoning_content,
-                    ..
-                } => {
+                Message::AssistantToolCalls { calls, .. } => {
+                    let blocks = calls
+                        .iter()
+                        .map(|call| {
+                            let input: Value = serde_json::from_str(&call.args)
+                                .unwrap_or_else(|_| Value::Object(Default::default()));
+                            AnthropicContentBlock::ToolUse {
+                                id: call.call_id.clone(),
+                                name: call.tool_name.clone(),
+                                input,
+                            }
+                        })
+                        .collect();
+                    (AnthropicRole::Assistant, blocks)
+                }
+                Message::AssistantResponse { content, .. } => {
                     let mut blocks = Vec::new();
-                    if let Some(rc) = reasoning_content {
-                        // The generic Message model does not store provider-specific signatures.
-                        // Therefore we send an empty signature here. This is a design boundary:
-                        // round-tripping a thinking block through the generic Message model will
-                        // lose the original signature, and the provider may reject it on
-                        // subsequent turns. A provider-specific storage layer would be needed
-                        // to preserve signatures across turns.
-                        blocks.push(AnthropicContentBlock::Thinking {
-                            thinking: rc.clone(),
-                            signature: String::new(),
-                        });
-                    }
                     for part in content {
                         match self.format_content_block(part) {
                             Ok(block) => blocks.push(block),
@@ -196,49 +182,37 @@ impl AnthropicCompatibleProvider {
             }
         }
 
-        let reasoning_content = if !thinking_parts.is_empty() {
-            Some(thinking_parts.join("\n"))
+        let thinking = if !thinking_parts.is_empty() {
+            let content = thinking_parts.join("\n");
+            Some(Message::AssistantThinking {
+                content,
+                signature: None,
+                created_at: Utc::now(),
+            })
         } else {
             None
         };
 
         if !tool_calls.is_empty() {
-            // For tool_calls path, if no thinking block was present but there is text content,
-            // fall back to using the text as reasoning_content to preserve backward-compatible
-            // behavior (older models may emit plain text before tool_use without a thinking block).
-            let reasoning_content = reasoning_content.or_else(|| {
-                if text_content.is_empty() {
-                    None
-                } else {
-                    let texts: Vec<String> = text_content
-                        .iter()
-                        .filter_map(|c| match c {
-                            Content::Text { text } => Some(text.clone()),
-                            _ => None,
-                        })
-                        .collect();
-                    Some(texts.join("\n"))
-                }
-            });
             return Ok(GenerationResponse {
                 message: Message::AssistantToolCalls {
                     calls: tool_calls,
-                    reasoning_content,
                     created_at: Utc::now(),
                 },
+                thinking,
             });
         }
 
-        if text_content.is_empty() && reasoning_content.is_none() {
+        if text_content.is_empty() && thinking.is_none() {
             return Err(BabataError::provider("No content in assistant message"));
         }
 
         Ok(GenerationResponse {
             message: Message::AssistantResponse {
                 content: text_content,
-                reasoning_content,
                 created_at: Utc::now(),
             },
+            thinking,
         })
     }
 }
@@ -525,13 +499,11 @@ mod tests {
     }
 
     #[test]
-    fn test_format_messages_encodes_reasoning_content_as_thinking_block_for_assistant_response() {
+    fn test_format_messages_maps_assistant_thinking_to_thinking_block() {
         let provider = AnthropicCompatibleProvider::new("test-key", "http://localhost");
-        let messages = vec![Message::AssistantResponse {
-            content: vec![Content::Text {
-                text: "The answer is 42.".to_string(),
-            }],
-            reasoning_content: Some("I need to calculate...".to_string()),
+        let messages = vec![Message::AssistantThinking {
+            content: "I need to calculate...".to_string(),
+            signature: None,
             created_at: chrono::Utc::now(),
         }];
         let anthropic_messages = provider
@@ -539,7 +511,7 @@ mod tests {
             .expect("format messages");
         assert_eq!(anthropic_messages.len(), 1);
         assert_eq!(anthropic_messages[0].role, AnthropicRole::Assistant);
-        assert_eq!(anthropic_messages[0].content.len(), 2);
+        assert_eq!(anthropic_messages[0].content.len(), 1);
 
         match &anthropic_messages[0].content[0] {
             AnthropicContentBlock::Thinking {
@@ -551,26 +523,26 @@ mod tests {
             }
             other => panic!("expected Thinking block, got {other:?}"),
         }
-        match &anthropic_messages[0].content[1] {
-            AnthropicContentBlock::Text { text } => {
-                assert_eq!(text, "The answer is 42.");
-            }
-            other => panic!("expected Text block, got {other:?}"),
-        }
     }
 
     #[test]
-    fn test_format_messages_encodes_reasoning_content_as_thinking_block_for_tool_calls() {
+    fn test_format_messages_merges_assistant_thinking_with_response() {
         let provider = AnthropicCompatibleProvider::new("test-key", "http://localhost");
-        let messages = vec![Message::AssistantToolCalls {
-            calls: vec![ToolCall {
-                call_id: "call-1".to_string(),
-                tool_name: "calculator".to_string(),
-                args: "{\"a\":1,\"b\":2}".to_string(),
-            }],
-            reasoning_content: Some("I should use a tool.".to_string()),
-            created_at: chrono::Utc::now(),
-        }];
+        let messages = vec![
+            Message::AssistantThinking {
+                content: "I should use a tool.".to_string(),
+                signature: Some("sig-123".to_string()),
+                created_at: chrono::Utc::now(),
+            },
+            Message::AssistantToolCalls {
+                calls: vec![ToolCall {
+                    call_id: "call-1".to_string(),
+                    tool_name: "calculator".to_string(),
+                    args: "{\"a\":1,\"b\":2}".to_string(),
+                }],
+                created_at: chrono::Utc::now(),
+            },
+        ];
         let anthropic_messages = provider
             .format_messages(&messages)
             .expect("format messages");
@@ -584,7 +556,7 @@ mod tests {
                 signature,
             } => {
                 assert_eq!(thinking, "I should use a tool.");
-                assert!(signature.is_empty());
+                assert_eq!(signature, "sig-123");
             }
             other => panic!("expected Thinking block, got {other:?}"),
         }
@@ -598,7 +570,7 @@ mod tests {
     }
 
     #[test]
-    fn test_response_parsing_extracts_thinking_block_as_reasoning_content() {
+    fn test_response_parsing_extracts_thinking_block_as_separate_message() {
         let provider = AnthropicCompatibleProvider::new("test-key", "http://localhost");
         let response_body = AnthropicResponse {
             id: "msg-1".to_string(),
@@ -621,11 +593,7 @@ mod tests {
             .parse_response(response_body)
             .expect("parse response");
         match response.message {
-            Message::AssistantResponse {
-                content,
-                reasoning_content,
-                ..
-            } => {
+            Message::AssistantResponse { content, .. } => {
                 assert_eq!(content.len(), 1);
                 assert_eq!(
                     content[0],
@@ -633,12 +601,18 @@ mod tests {
                         text: "Here is my analysis.".to_string()
                     }
                 );
-                assert_eq!(
-                    reasoning_content,
-                    Some("Let me analyze this...".to_string())
-                );
             }
             other => panic!("expected AssistantResponse, got {other:?}"),
+        }
+        let thinking = response.thinking.expect("should have thinking");
+        match thinking {
+            Message::AssistantThinking {
+                content, signature, ..
+            } => {
+                assert_eq!(content, "Let me analyze this...");
+                assert_eq!(signature, None);
+            }
+            other => panic!("expected AssistantThinking, got {other:?}"),
         }
     }
 
@@ -671,25 +645,25 @@ mod tests {
             .parse_response(response_body)
             .expect("parse response");
         match response.message {
-            Message::AssistantToolCalls {
-                calls,
-                reasoning_content,
-                ..
-            } => {
+            Message::AssistantToolCalls { calls, .. } => {
                 assert_eq!(calls.len(), 1);
                 assert_eq!(calls[0].call_id, "tool-1");
                 assert_eq!(calls[0].tool_name, "search");
-                // thinking text goes to reasoning_content; regular text is not used as
-                // reasoning_content because a thinking block was present
-                assert_eq!(reasoning_content, Some("I need to search.".to_string()));
             }
             other => panic!("expected AssistantToolCalls, got {other:?}"),
         }
+        let thinking = response.thinking.expect("should have thinking");
+        match thinking {
+            Message::AssistantThinking { content, .. } => {
+                assert_eq!(content, "I need to search.");
+            }
+            other => panic!("expected AssistantThinking, got {other:?}"),
+        }
     }
 
-    // Regression test: plain text response (no thinking block) must have reasoning_content == None
+    // Regression test: plain text response (no thinking block) must have thinking == None
     #[test]
-    fn test_response_parsing_plain_text_has_no_reasoning_content() {
+    fn test_response_parsing_plain_text_has_no_thinking() {
         let provider = AnthropicCompatibleProvider::new("test-key", "http://localhost");
         let response_body = AnthropicResponse {
             id: "msg-1".to_string(),
@@ -706,11 +680,7 @@ mod tests {
             .parse_response(response_body)
             .expect("parse response");
         match response.message {
-            Message::AssistantResponse {
-                content,
-                reasoning_content,
-                ..
-            } => {
+            Message::AssistantResponse { content, .. } => {
                 assert_eq!(content.len(), 1);
                 assert_eq!(
                     content[0],
@@ -718,10 +688,10 @@ mod tests {
                         text: "Hello, world!".to_string()
                     }
                 );
-                assert_eq!(reasoning_content, None);
             }
             other => panic!("expected AssistantResponse, got {other:?}"),
         }
+        assert!(response.thinking.is_none());
     }
 
     // Tests for AnthropicImageSource with base64 and url types

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -73,6 +73,7 @@ pub struct GenerationRequest<'a> {
 
 pub struct GenerationResponse {
     pub message: Message,
+    pub thinking: Option<Message>,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/provider/openai_compatible.rs
+++ b/src/provider/openai_compatible.rs
@@ -79,6 +79,8 @@ impl OpenAICompatibleProvider {
             }
         }
 
+        let mut pending_reasoning: Option<String> = None;
+
         for message in prompts {
             match message {
                 Message::UserPrompt { content, .. } | Message::UserSteering { content, .. } => {
@@ -114,11 +116,13 @@ impl OpenAICompatibleProvider {
 
                     request_messages.push(ChatCompletionMessageParam::User { content: parts });
                 }
-                Message::AssistantToolCalls {
-                    calls,
-                    reasoning_content,
-                    ..
-                } => {
+                Message::AssistantThinking { content, .. } => {
+                    pending_reasoning = Some(
+                        pending_reasoning
+                            .map_or_else(|| content.clone(), |p| format!("{}\n{}", p, content)),
+                    );
+                }
+                Message::AssistantToolCalls { calls, .. } => {
                     let tool_calls = calls
                         .iter()
                         .map(|call| ChatCompletionMessageToolCall::Function {
@@ -132,15 +136,11 @@ impl OpenAICompatibleProvider {
 
                     request_messages.push(ChatCompletionMessageParam::Assistant {
                         content: None,
-                        reasoning_content: reasoning_content.clone(),
+                        reasoning_content: pending_reasoning.take(),
                         tool_calls: Some(tool_calls),
                     });
                 }
-                Message::AssistantResponse {
-                    content,
-                    reasoning_content,
-                    ..
-                } => {
+                Message::AssistantResponse { content, .. } => {
                     let mut parts = Vec::with_capacity(content.len());
                     for part in content {
                         match part {
@@ -159,7 +159,7 @@ impl OpenAICompatibleProvider {
 
                     request_messages.push(ChatCompletionMessageParam::Assistant {
                         content: Some(parts),
-                        reasoning_content: reasoning_content.clone(),
+                        reasoning_content: pending_reasoning.take(),
                         tool_calls: None,
                     });
                 }
@@ -253,6 +253,18 @@ impl Provider for OpenAICompatibleProvider {
 
         let choice = response_body.choices.remove(0);
 
+        let thinking = choice.message.reasoning_content.clone().and_then(|rc| {
+            if rc.trim().is_empty() {
+                None
+            } else {
+                Some(Message::AssistantThinking {
+                    content: rc,
+                    signature: None,
+                    created_at: Utc::now(),
+                })
+            }
+        });
+
         if let Some(tool_calls) = choice.message.tool_calls {
             let mut parsed_calls = Vec::with_capacity(tool_calls.len());
             for tool_call in tool_calls {
@@ -268,9 +280,9 @@ impl Provider for OpenAICompatibleProvider {
                 return Ok(GenerationResponse {
                     message: Message::AssistantToolCalls {
                         calls: parsed_calls,
-                        reasoning_content: choice.message.reasoning_content,
                         created_at: Utc::now(),
                     },
+                    thinking,
                 });
             }
         }
@@ -282,9 +294,9 @@ impl Provider for OpenAICompatibleProvider {
         Ok(GenerationResponse {
             message: Message::AssistantResponse {
                 content: vec![Content::Text { text: content }],
-                reasoning_content: choice.message.reasoning_content,
                 created_at: Utc::now(),
             },
+            thinking,
         })
     }
 }

--- a/src/provider/openai_compatible.rs
+++ b/src/provider/openai_compatible.rs
@@ -172,6 +172,13 @@ impl OpenAICompatibleProvider {
             }
         }
 
+        if let Some(reasoning) = pending_reasoning {
+            warn!(
+                "OpenAI-compatible provider: pending reasoning content was not consumed: {}",
+                reasoning
+            );
+        }
+
         Ok(request_messages)
     }
 }

--- a/src/tool/query_messages.rs
+++ b/src/tool/query_messages.rs
@@ -27,7 +27,7 @@ impl QueryMessagesTool {
                 description: "Query messages from the message store using a SQL SELECT statement. \
                     Returns each row as a JSON object. \
                     The messages table has columns: task_id, message_type, content, \
-                    reasoning_content, tool_calls, result, created_at."
+                    signature, tool_calls, result, created_at."
                     .to_string(),
                 parameters: schemars::schema_for!(QueryMessagesArgs),
             },

--- a/src/tool/shell.rs
+++ b/src/tool/shell.rs
@@ -213,7 +213,7 @@ mod tests {
     fn detect_shell_type_matches_platform() {
         let shell = detect_shell_type();
         if std::env::consts::OS == "windows" {
-            assert_eq!(shell, "powershell");
+            assert_eq!(shell, "powershell.exe");
         } else {
             assert_eq!(shell, "bash");
         }


### PR DESCRIPTION
## Summary

This PR refactors the message model to separate thinking content into its own Message variant, removing easoning_content from assistant-facing message types and updating the persistence layer, provider layer, and agent runner accordingly.

## Key Changes

### Message Model
- **Add** Message::AssistantThinking { content, signature } as a dedicated variant.
- **Remove** easoning_content field from AssistantResponse and AssistantToolCalls.

### Persistence Layer (src/memory/)
- Refactor MessageRecord and the messages SQLite table: replace easoning_content column with signature.
- Add idempotent DB migration (ALTER TABLE messages ADD COLUMN signature TEXT) for existing databases.
- Add MessageType::AssistantThinking for storage roundtrip.
- Memory context building (ender_context) now explicitly filters out AssistantThinking so thinking blocks do not leak into LLM context.

### Provider Layer (src/provider/)
- GenerationResponse now carries 	hinking: Option<Message> **separate** from message.
- Provider call chain separates thinking from the final assistant message.
- **Anthropic provider**: AssistantThinking maps to/from Thinking block; merged with adjacent assistant messages via existing same-role merge logic.
- **OpenAI-compatible provider**: AssistantThinking accumulates as pending_reasoning_content for the next assistant message; warns if reasoning is left unconsumed.

### Agent Runner (src/agent/runner.rs)
- Persist thinking to memory/conversation **before** processing the primary message.
- Guard: reject AssistantThinking if a provider incorrectly returns it as the primary message, preventing dirty data.

### Scope
- Rust code only — no frontend changes.
- No backward-compatibility read logic for the old easoning_content field.

## Files Changed

| File | Changes |
|------|---------|
| src/message.rs | Add AssistantThinking variant, remove easoning_content |
| src/memory/store.rs | Table schema, migration, record mapping, tests |
| src/memory/mod.rs | Context filtering, new tests |
| src/provider/mod.rs | GenerationResponse.thinking field |
| src/provider/anthropic_compatible.rs | Thinking block bidirectional mapping |
| src/provider/openai_compatible.rs | Pending reasoning handling |
| src/agent/runner.rs | Separate thinking persistence + guard |
| src/tool/query_messages.rs | Update query schema |
| src/tool/shell.rs | Minor update |

## Commits

- 576fbd5 feat(anthropic): support thinking block bidirectional mapping
- 5620b0c feat(message): refactor thinking into separate AssistantThinking variant
- 9e225fc fix: address code-review must-fix items