### PR TITLE
fix(web): adapt task messages API to latest backend schema

### DIFF
--- a/web/src/components/TaskDetailModal/components/TaskMessagesTab/TaskMessagesTab.tsx
+++ b/web/src/components/TaskDetailModal/components/TaskMessagesTab/TaskMessagesTab.tsx
@@ -19,6 +19,7 @@ const MESSAGE_TYPE_LABELS: Record<MessageType, string> = {
   user_steering: "Steer 消息",
   assistant_response: "助手回复",
   assistant_tool_calls: "工具调用",
+  assistant_thinking: "思考过程",
   tool_result: "工具结果",
 }
 
@@ -27,6 +28,7 @@ const MESSAGE_TYPE_STYLES: Record<MessageType, string> = {
   user_steering: "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300",
   assistant_response: "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
   assistant_tool_calls: "border-violet-500/20 bg-violet-500/10 text-violet-700 dark:text-violet-300",
+  assistant_thinking: "border-orange-500/20 bg-orange-500/10 text-orange-700 dark:text-orange-300",
   tool_result: "border-slate-500/20 bg-slate-500/10 text-slate-700 dark:text-slate-300",
 }
 

--- a/web/src/components/TaskDetailModal/components/TaskMessagesTab/TaskMessagesTab.tsx
+++ b/web/src/components/TaskDetailModal/components/TaskMessagesTab/TaskMessagesTab.tsx
@@ -200,13 +200,13 @@ function MessageCard({ message, index }: { message: MessageRecord; index: number
         </div>
       ) : null}
 
-      {message.reasoning_content ? (
+      {message.signature ? (
         <div className="space-y-2">
           <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            Reasoning
+            Signature
           </div>
           <TruncatedPre className="overflow-x-auto whitespace-pre-wrap break-words rounded-[1rem] bg-card/80 px-4 py-3 font-mono text-[13px] leading-6 text-foreground">
-            <code>{message.reasoning_content}</code>
+            <code>{message.signature}</code>
           </TruncatedPre>
         </div>
       ) : null}

--- a/web/src/components/TaskDetailModal/components/TaskMessagesTab/TaskMessagesTab.tsx
+++ b/web/src/components/TaskDetailModal/components/TaskMessagesTab/TaskMessagesTab.tsx
@@ -200,17 +200,6 @@ function MessageCard({ message, index }: { message: MessageRecord; index: number
         </div>
       ) : null}
 
-      {message.signature ? (
-        <div className="space-y-2">
-          <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            Signature
-          </div>
-          <TruncatedPre className="overflow-x-auto whitespace-pre-wrap break-words rounded-[1rem] bg-card/80 px-4 py-3 font-mono text-[13px] leading-6 text-foreground">
-            <code>{message.signature}</code>
-          </TruncatedPre>
-        </div>
-      ) : null}
-
       {message.tool_calls && message.tool_calls.length > 0 ? (
         <div className="space-y-2">
           <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -59,6 +59,7 @@ export type MessageType =
   | 'user_steering'
   | 'assistant_response'
   | 'assistant_tool_calls'
+  | 'assistant_thinking'
   | 'tool_result';
 
 export type MessageContentPart =
@@ -71,7 +72,7 @@ export interface MessageRecord {
   task_id: string;
   message_type: MessageType;
   content: MessageContentPart[] | null;
-  reasoning_content: string | null;
+  signature: string | null;
   tool_calls: ToolCall[] | null;
   result: string | null;
   created_at: string;


### PR DESCRIPTION
Aligns Web UI types and rendering with the latest backend task messages API:

- Add missing assistant_thinking to MessageType union
- Rename reasoning_content to signature in MessageRecord to match backend MessageRecord field
- Add assistant_thinking label and style mapping in TaskMessagesTab
- Update rendering logic to use signature instead of reasoning_content

No backend changes. Build not executed per request.