### PR TITLE
fix(web): add fallback for message type label and style lookup in tas…

### DIFF
--- a/web/src/components/TaskDetailModal/components/TaskMessagesTab/TaskMessagesTab.tsx
+++ b/web/src/components/TaskDetailModal/components/TaskMessagesTab/TaskMessagesTab.tsx
@@ -23,13 +23,25 @@ const MESSAGE_TYPE_LABELS: Record<MessageType, string> = {
   tool_result: "工具结果",
 }
 
+const DEFAULT_MESSAGE_STYLE = "border-slate-500/20 bg-slate-500/10 text-slate-700 dark:text-slate-300"
+
 const MESSAGE_TYPE_STYLES: Record<MessageType, string> = {
   user_prompt: "border-sky-500/20 bg-sky-500/10 text-sky-700 dark:text-sky-300",
   user_steering: "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300",
   assistant_response: "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
   assistant_tool_calls: "border-violet-500/20 bg-violet-500/10 text-violet-700 dark:text-violet-300",
   assistant_thinking: "border-orange-500/20 bg-orange-500/10 text-orange-700 dark:text-orange-300",
-  tool_result: "border-slate-500/20 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+  tool_result: DEFAULT_MESSAGE_STYLE,
+}
+
+function getMessageTypeLabel(type: MessageType): string {
+  // Fallback for runtime type mismatch or future message types
+  return MESSAGE_TYPE_LABELS[type] ?? type
+}
+
+function getMessageTypeStyle(type: MessageType): string {
+  // Fallback for runtime type mismatch or future message types
+  return MESSAGE_TYPE_STYLES[type] ?? DEFAULT_MESSAGE_STYLE
 }
 
 function formatTime(timestamp: string) {
@@ -181,9 +193,9 @@ function MessageCard({ message, index }: { message: MessageRecord; index: number
           <div className="text-xs font-medium text-muted-foreground">#{index + 1}</div>
           <Badge
             variant="outline"
-            className={`rounded-full ${MESSAGE_TYPE_STYLES[message.message_type]}`}
+            className={`rounded-full ${getMessageTypeStyle(message.message_type)}`}
           >
-            {MESSAGE_TYPE_LABELS[message.message_type]}
+            {getMessageTypeLabel(message.message_type)}
           </Badge>
         </div>
         <div className="text-xs text-muted-foreground">{formatTime(message.created_at)}</div>


### PR DESCRIPTION
…k messages tab

The TaskMessagesTab component directly indexes MESSAGE_TYPE_LABELS and MESSAGE_TYPE_STYLES with message.message_type. While the current mappings include assistant_thinking, this direct index access is fragile: if the backend ever returns a message_type not present in the frontend maps (e.g. due to serialization mismatch, stale DB data, or a newly added type), the Badge renders empty text and an undefined CSS class.

This change introduces getMessageTypeLabel() and getMessageTypeStyle() helper functions with safe fallbacks, ensuring the message card header always displays a meaningful label and valid styles.