### PR TITLE
feat: add task message/log filtering in API and web UI

### DIFF
--- a/src/http/get_task_logs.rs
+++ b/src/http/get_task_logs.rs
@@ -39,15 +39,13 @@ impl std::str::FromStr for LogLevel {
 impl LogLevel {
     fn matches(&self, log: &str) -> bool {
         let upper_log = log.to_ascii_uppercase();
+        // Log lines typically look like: "2024-01-01 12:00:00 [INFO] [task-id] message"
+        // We check for the level enclosed in brackets [LEVEL] to avoid false positives in the message body.
         match self {
-            LogLevel::Error => upper_log.contains("[ERROR]") || upper_log.contains(" ERROR "),
-            LogLevel::Warn => {
-                upper_log.contains("[WARN]")
-                    || upper_log.contains(" WARNING ")
-                    || upper_log.contains(" WARN ")
-            }
-            LogLevel::Info => upper_log.contains("[INFO]") || upper_log.contains(" INFO "),
-            LogLevel::Debug => upper_log.contains("[DEBUG]") || upper_log.contains(" DEBUG "),
+            LogLevel::Error => upper_log.contains("[ERROR]"),
+            LogLevel::Warn => upper_log.contains("[WARN]") || upper_log.contains("[WARNING]"),
+            LogLevel::Info => upper_log.contains("[INFO]"),
+            LogLevel::Debug => upper_log.contains("[DEBUG]"),
         }
     }
 }
@@ -151,7 +149,9 @@ async fn read_task_logs(
                 for line in &lines {
                     if line.contains(&task_marker) {
                         // Apply level filter if specified
-                        if let Some(ref level) = level_filter && !level.matches(line) {
+                        if let Some(ref level) = level_filter
+                            && !level.matches(line)
+                        {
                             continue;
                         }
                         matching_lines_in_file.push(line.to_string());
@@ -223,20 +223,18 @@ mod tests {
     #[test]
     fn log_level_matches_correctly() {
         assert!(LogLevel::Error.matches("2024-01-01 [task-id] [ERROR] something failed"));
-        assert!(LogLevel::Error.matches("2024-01-01 ERROR something failed"));
-        assert!(!LogLevel::Error.matches("2024-01-01 [INFO] all good"));
+        assert!(!LogLevel::Error.matches("2024-01-01 [task-id] [INFO] ERROR in request body"));
+        assert!(!LogLevel::Error.matches("2024-01-01 [task-id] [WARN] error sending request"));
+        assert!(!LogLevel::Error.matches("2024-01-01 [task-id] [INFO] all good"));
 
         assert!(LogLevel::Warn.matches("2024-01-01 [task-id] [WARN] caution"));
-        assert!(LogLevel::Warn.matches("2024-01-01 WARNING caution"));
-        assert!(LogLevel::Warn.matches("2024-01-01 WARN caution"));
-        assert!(!LogLevel::Warn.matches("2024-01-01 [ERROR] failed"));
+        assert!(LogLevel::Warn.matches("2024-01-01 [task-id] [WARNING] caution"));
+        assert!(!LogLevel::Warn.matches("2024-01-01 [task-id] [ERROR] failed"));
 
         assert!(LogLevel::Info.matches("2024-01-01 [task-id] [INFO] started"));
-        assert!(LogLevel::Info.matches("2024-01-01 INFO started"));
-        assert!(!LogLevel::Info.matches("2024-01-01 [DEBUG] trace"));
+        assert!(!LogLevel::Info.matches("2024-01-01 [task-id] [DEBUG] trace"));
 
         assert!(LogLevel::Debug.matches("2024-01-01 [task-id] [DEBUG] trace"));
-        assert!(LogLevel::Debug.matches("2024-01-01 DEBUG trace"));
-        assert!(!LogLevel::Debug.matches("2024-01-01 [INFO] normal"));
+        assert!(!LogLevel::Debug.matches("2024-01-01 [task-id] [INFO] normal"));
     }
 }

--- a/src/http/get_task_logs.rs
+++ b/src/http/get_task_logs.rs
@@ -10,6 +10,48 @@ use super::{HttpApp, ensure_task_exists, parse_task_id};
 
 const MAX_LIMIT: usize = 1000;
 
+/// Supported log levels for filtering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+impl std::str::FromStr for LogLevel {
+    type Err = BabataError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_uppercase().as_str() {
+            "ERROR" => Ok(LogLevel::Error),
+            "WARN" | "WARNING" => Ok(LogLevel::Warn),
+            "INFO" => Ok(LogLevel::Info),
+            "DEBUG" => Ok(LogLevel::Debug),
+            _ => Err(BabataError::invalid_input(format!(
+                "Invalid log level '{}'. Supported: ERROR, WARN, INFO, DEBUG",
+                s
+            ))),
+        }
+    }
+}
+
+impl LogLevel {
+    fn matches(&self, log: &str) -> bool {
+        let upper_log = log.to_ascii_uppercase();
+        match self {
+            LogLevel::Error => upper_log.contains("[ERROR]") || upper_log.contains(" ERROR "),
+            LogLevel::Warn => {
+                upper_log.contains("[WARN]")
+                    || upper_log.contains(" WARNING ")
+                    || upper_log.contains(" WARN ")
+            }
+            LogLevel::Info => upper_log.contains("[INFO]") || upper_log.contains(" INFO "),
+            LogLevel::Debug => upper_log.contains("[DEBUG]") || upper_log.contains(" DEBUG "),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct LogQueryParams {
     /// Required: Maximum number of log lines to return (1-1000)
@@ -17,6 +59,8 @@ pub(crate) struct LogQueryParams {
     /// Optional: Number of lines to skip (default: 0)
     #[serde(default)]
     offset: usize,
+    /// Optional: Filter by log level (ERROR, WARN, INFO, DEBUG)
+    level: Option<String>,
 }
 
 pub(super) async fn handle(
@@ -37,9 +81,19 @@ pub(super) async fn handle(
         )));
     }
 
-    let logs = read_task_logs(&task_id.to_string(), params.offset, params.limit)
-        .await
-        .map_err(|err| BabataError::invalid_input(format!("Failed to read logs: {}", err)))?;
+    let level_filter = match params.level {
+        Some(ref s) => Some(s.parse::<LogLevel>()?),
+        None => None,
+    };
+
+    let logs = read_task_logs(
+        &task_id.to_string(),
+        params.offset,
+        params.limit,
+        level_filter,
+    )
+    .await
+    .map_err(|err| BabataError::invalid_input(format!("Failed to read logs: {}", err)))?;
     Ok(Json(logs))
 }
 
@@ -49,6 +103,7 @@ async fn read_task_logs(
     task_id: &str,
     offset: usize,
     limit: usize,
+    level_filter: Option<LogLevel>,
 ) -> Result<Vec<String>, std::io::Error> {
     let log_dir = babata_dir()
         .map_err(|e| std::io::Error::other(e.to_string()))?
@@ -95,6 +150,10 @@ async fn read_task_logs(
                 let task_marker = format!("[{}]", task_id);
                 for line in &lines {
                     if line.contains(&task_marker) {
+                        // Apply level filter if specified
+                        if let Some(ref level) = level_filter && !level.matches(line) {
+                            continue;
+                        }
                         matching_lines_in_file.push(line.to_string());
                     }
                 }
@@ -136,4 +195,48 @@ async fn read_task_logs(
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LogLevel;
+
+    #[test]
+    fn log_level_from_str_parses_case_insensitive() {
+        assert_eq!("ERROR".parse::<LogLevel>().unwrap(), LogLevel::Error);
+        assert_eq!("error".parse::<LogLevel>().unwrap(), LogLevel::Error);
+        assert_eq!("WARN".parse::<LogLevel>().unwrap(), LogLevel::Warn);
+        assert_eq!("warn".parse::<LogLevel>().unwrap(), LogLevel::Warn);
+        assert_eq!("WARNING".parse::<LogLevel>().unwrap(), LogLevel::Warn);
+        assert_eq!("INFO".parse::<LogLevel>().unwrap(), LogLevel::Info);
+        assert_eq!("info".parse::<LogLevel>().unwrap(), LogLevel::Info);
+        assert_eq!("DEBUG".parse::<LogLevel>().unwrap(), LogLevel::Debug);
+        assert_eq!("debug".parse::<LogLevel>().unwrap(), LogLevel::Debug);
+    }
+
+    #[test]
+    fn log_level_from_str_rejects_invalid() {
+        let err = "TRACE".parse::<LogLevel>().expect_err("TRACE should fail");
+        assert!(err.to_string().contains("Invalid log level"));
+    }
+
+    #[test]
+    fn log_level_matches_correctly() {
+        assert!(LogLevel::Error.matches("2024-01-01 [task-id] [ERROR] something failed"));
+        assert!(LogLevel::Error.matches("2024-01-01 ERROR something failed"));
+        assert!(!LogLevel::Error.matches("2024-01-01 [INFO] all good"));
+
+        assert!(LogLevel::Warn.matches("2024-01-01 [task-id] [WARN] caution"));
+        assert!(LogLevel::Warn.matches("2024-01-01 WARNING caution"));
+        assert!(LogLevel::Warn.matches("2024-01-01 WARN caution"));
+        assert!(!LogLevel::Warn.matches("2024-01-01 [ERROR] failed"));
+
+        assert!(LogLevel::Info.matches("2024-01-01 [task-id] [INFO] started"));
+        assert!(LogLevel::Info.matches("2024-01-01 INFO started"));
+        assert!(!LogLevel::Info.matches("2024-01-01 [DEBUG] trace"));
+
+        assert!(LogLevel::Debug.matches("2024-01-01 [task-id] [DEBUG] trace"));
+        assert!(LogLevel::Debug.matches("2024-01-01 DEBUG trace"));
+        assert!(!LogLevel::Debug.matches("2024-01-01 [INFO] normal"));
+    }
 }

--- a/src/http/get_task_messages.rs
+++ b/src/http/get_task_messages.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use axum::{
     Json,
     extract::{Path, Query, State},
@@ -15,6 +17,7 @@ pub(crate) struct MessageQueryParams {
     limit: usize,
     #[serde(default)]
     offset: usize,
+    message_type: Option<String>,
 }
 
 pub(super) async fn handle(
@@ -35,8 +38,17 @@ pub(super) async fn handle(
         )));
     }
 
-    let messages = state
-        .task_manager
-        .get_task_messages(task_id, params.offset, params.limit)?;
+    let message_type = match params.message_type {
+        Some(ref s) => Some(
+            crate::memory::MessageType::from_str(s)
+                .map_err(|_| BabataError::invalid_input(format!("Invalid message_type '{}'", s)))?,
+        ),
+        None => None,
+    };
+
+    let messages =
+        state
+            .task_manager
+            .get_task_messages(task_id, params.offset, params.limit, message_type)?;
     Ok(Json(messages))
 }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2,6 +2,7 @@ mod store;
 
 pub use store::MessageRecord;
 pub use store::MessageStore;
+pub use store::MessageType;
 
 use std::path::{Path, PathBuf};
 
@@ -83,8 +84,10 @@ This file stores important information that should persist across sessions.
         task_id: Uuid,
         offset: usize,
         limit: usize,
+        message_type: Option<MessageType>,
     ) -> BabataResult<Vec<MessageRecord>> {
-        self.store.scan_task_message_records(task_id, offset, limit)
+        self.store
+            .scan_task_message_records(task_id, offset, limit, message_type)
     }
 
     fn render_context(messages: &[Message]) -> String {

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -400,17 +400,25 @@ impl MessageStore {
         task_id: Uuid,
         offset: usize,
         limit: usize,
+        message_type: Option<MessageType>,
     ) -> BabataResult<Vec<MessageRecord>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
 
-        let query =
+        let query = if message_type.is_some() {
+            "SELECT task_id, message_type, content, signature, tool_calls, result, created_at
+            FROM messages
+            WHERE task_id = ?1 AND message_type = ?2
+            ORDER BY datetime(created_at), rowid
+            LIMIT ?3 OFFSET ?4"
+        } else {
             "SELECT task_id, message_type, content, signature, tool_calls, result, created_at
             FROM messages
             WHERE task_id = ?1
             ORDER BY datetime(created_at), rowid
-            LIMIT ?2 OFFSET ?3";
+            LIMIT ?2 OFFSET ?3"
+        };
 
         let task_id_param = task_id.to_string();
         let limit_param = limit.min(i64::MAX as usize) as i64;
@@ -424,14 +432,22 @@ impl MessageStore {
             ))
         })?;
 
-        let mut rows = stmt
-            .query(params![task_id_param, limit_param, offset_param])
-            .map_err(|err| {
-                BabataError::memory(format!(
-                    "Failed to query task messages from sqlite: {}",
-                    err
-                ))
-            })?;
+        let mut rows = if let Some(mt) = message_type {
+            stmt.query(params![
+                task_id_param,
+                mt.to_string(),
+                limit_param,
+                offset_param
+            ])
+        } else {
+            stmt.query(params![task_id_param, limit_param, offset_param])
+        }
+        .map_err(|err| {
+            BabataError::memory(format!(
+                "Failed to query task messages from sqlite: {}",
+                err
+            ))
+        })?;
 
         let mut records = Vec::new();
         while let Some(row) = rows.next().map_err(|err| {
@@ -827,7 +843,7 @@ mod tests {
             .expect("insert other task message");
 
         let records = store
-            .scan_task_message_records(task_id, 1, 2)
+            .scan_task_message_records(task_id, 1, 2, None)
             .expect("scan paginated task message records");
 
         assert_eq!(records.len(), 2);
@@ -835,6 +851,100 @@ mod tests {
         assert_eq!(records[0].message_type, MessageType::UserSteering);
         assert_eq!(records[1].task_id, task_id);
         assert_eq!(records[1].message_type, MessageType::AssistantResponse);
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn scan_task_message_records_with_message_type_filter() {
+        let db_path = std::env::temp_dir()
+            .join("babata-tests")
+            .join(format!("message-store-filter-{}.db", Uuid::new_v4()));
+
+        let store = MessageStore::open(&db_path).expect("open sqlite message store");
+        let task_id = Uuid::new_v4();
+        let now = Utc::now();
+
+        store
+            .append_messages(
+                task_id,
+                &[
+                    Message::UserPrompt {
+                        content: vec![Content::Text {
+                            text: "user message 1".to_string(),
+                        }],
+                        created_at: now,
+                    },
+                    Message::AssistantResponse {
+                        content: vec![Content::Text {
+                            text: "assistant response 1".to_string(),
+                        }],
+                        created_at: now + chrono::Duration::seconds(1),
+                    },
+                    Message::UserPrompt {
+                        content: vec![Content::Text {
+                            text: "user message 2".to_string(),
+                        }],
+                        created_at: now + chrono::Duration::seconds(2),
+                    },
+                    Message::AssistantToolCalls {
+                        calls: vec![ToolCall {
+                            call_id: "call-1".to_string(),
+                            tool_name: "read_file".to_string(),
+                            args: r#"{"path": "README.md"}"#.to_string(),
+                        }],
+                        created_at: now + chrono::Duration::seconds(3),
+                    },
+                ],
+            )
+            .expect("insert messages");
+
+        // Filter by user_prompt - should return 2 messages
+        let user_records = store
+            .scan_task_message_records(task_id, 0, 10, Some(MessageType::UserPrompt))
+            .expect("scan with user_prompt filter");
+        assert_eq!(user_records.len(), 2);
+        assert!(
+            user_records
+                .iter()
+                .all(|r| r.message_type == MessageType::UserPrompt)
+        );
+
+        // Filter by assistant_response - should return 1 message
+        let assistant_records = store
+            .scan_task_message_records(task_id, 0, 10, Some(MessageType::AssistantResponse))
+            .expect("scan with assistant_response filter");
+        assert_eq!(assistant_records.len(), 1);
+        assert_eq!(
+            assistant_records[0].message_type,
+            MessageType::AssistantResponse
+        );
+
+        // Filter by assistant_tool_calls - should return 1 message
+        let tool_call_records = store
+            .scan_task_message_records(task_id, 0, 10, Some(MessageType::AssistantToolCalls))
+            .expect("scan with assistant_tool_calls filter");
+        assert_eq!(tool_call_records.len(), 1);
+        assert_eq!(
+            tool_call_records[0].message_type,
+            MessageType::AssistantToolCalls
+        );
+
+        // No filter - should return all 4 messages
+        let all_records = store
+            .scan_task_message_records(task_id, 0, 10, None)
+            .expect("scan without filter");
+        assert_eq!(all_records.len(), 4);
+
+        // Filter with pagination
+        let paginated_user_records = store
+            .scan_task_message_records(task_id, 1, 10, Some(MessageType::UserPrompt))
+            .expect("scan with filter and offset");
+        assert_eq!(paginated_user_records.len(), 1);
+        assert_eq!(
+            paginated_user_records[0].message_type,
+            MessageType::UserPrompt
+        );
 
         let _ = std::fs::remove_file(db_path);
     }

--- a/src/task/manager.rs
+++ b/src/task/manager.rs
@@ -372,11 +372,12 @@ impl TaskManager {
         task_id: Uuid,
         offset: usize,
         limit: usize,
+        message_type: Option<crate::memory::MessageType>,
     ) -> BabataResult<Vec<MessageRecord>> {
         let task = self.store.get_task(task_id)?;
         let agent_dir = agent_dir(&task.agent)?;
         let memory = Memory::new(agent_dir)?;
-        memory.scan_task_message_records(task_id, offset, limit)
+        memory.scan_task_message_records(task_id, offset, limit, message_type)
     }
 
     pub fn get_pending_steer_messages(&self, task_id: Uuid) -> Vec<SteerMessage> {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -127,10 +127,16 @@ export async function getTaskFile(taskId: string, path: string): Promise<string>
   });
 }
 
-export function getTaskLogs(taskId: string, limit?: number, offset?: number): Promise<string[]> {
+export function getTaskLogs(
+  taskId: string,
+  limit?: number,
+  offset?: number,
+  level?: string
+): Promise<string[]> {
   const params = new URLSearchParams();
   if (limit !== undefined) params.append('limit', limit.toString());
   if (offset !== undefined) params.append('offset', offset.toString());
+  if (level && level !== 'all') params.append('level', level);
 
   const queryString = params.toString();
   return fetchApi<string[]>(`/tasks/${taskId}/logs${queryString ? `?${queryString}` : ''}`);
@@ -152,11 +158,13 @@ function parseJsonStringArray<T>(value: string | null): T[] | null {
 export async function getTaskMessages(
   taskId: string,
   limit: number,
-  offset?: number
+  offset?: number,
+  messageType?: string
 ): Promise<MessageRecord[]> {
   const params = new URLSearchParams();
   params.append('limit', limit.toString());
   if (offset !== undefined) params.append('offset', offset.toString());
+  if (messageType && messageType !== 'all') params.append('message_type', messageType);
 
   const queryString = params.toString();
   const response = await fetchApi<MessageRecordApiResponse[]>(

--- a/web/src/components/TaskDetailModal/components/TaskLogsTab/TaskLogsTab.tsx
+++ b/web/src/components/TaskDetailModal/components/TaskLogsTab/TaskLogsTab.tsx
@@ -5,6 +5,15 @@ import { getTaskLogs } from "@/api"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import type { LogLevel } from "@/types"
+import { LOG_LEVEL_OPTIONS } from "@/types"
 
 const PAGE_SIZE = 100
 const LOAD_MORE_THRESHOLD = 120
@@ -57,6 +66,7 @@ export function TaskLogsTab({ taskId }: TaskLogsTabProps) {
   const [error, setError] = useState<string | null>(null)
   const [hasMore, setHasMore] = useState(true)
   const [copied, setCopied] = useState(false)
+  const [levelFilter, setLevelFilter] = useState<LogLevel | 'all'>('all')
 
   const loadLogs = useCallback(async (offset: number, reset: boolean) => {
     if (reset) {
@@ -67,7 +77,7 @@ export function TaskLogsTab({ taskId }: TaskLogsTabProps) {
     }
 
     try {
-      const nextLogs = await getTaskLogs(taskId, PAGE_SIZE, offset)
+      const nextLogs = await getTaskLogs(taskId, PAGE_SIZE, offset, levelFilter)
 
       setLogs((current) => (reset ? nextLogs : [...current, ...nextLogs]))
       setHasMore(nextLogs.length === PAGE_SIZE)
@@ -77,14 +87,14 @@ export function TaskLogsTab({ taskId }: TaskLogsTabProps) {
       setLoading(false)
       setLoadingMore(false)
     }
-  }, [taskId])
+  }, [taskId, levelFilter])
 
   useEffect(() => {
     setLogs([])
     setHasMore(true)
     setError(null)
     void loadLogs(0, true)
-  }, [loadLogs, taskId])
+  }, [loadLogs, taskId, levelFilter])
 
   const handleScroll = useCallback((event: UIEvent<HTMLDivElement>) => {
     const target = event.currentTarget
@@ -196,6 +206,21 @@ export function TaskLogsTab({ taskId }: TaskLogsTabProps) {
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
+            <Select
+              value={levelFilter}
+              onValueChange={(value) => setLevelFilter(value as LogLevel | 'all')}
+            >
+              <SelectTrigger className="h-8 w-[140px] rounded-full text-xs">
+                <SelectValue placeholder="日志级别" />
+              </SelectTrigger>
+              <SelectContent>
+                {LOG_LEVEL_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             <Button
               variant="outline"
               size="sm"

--- a/web/src/components/TaskDetailModal/components/TaskMessagesTab/TaskMessagesTab.tsx
+++ b/web/src/components/TaskDetailModal/components/TaskMessagesTab/TaskMessagesTab.tsx
@@ -5,7 +5,15 @@ import { getTaskMessages } from "@/api"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import type { MessageContentPart, MessageRecord, MessageType, ToolCall } from "@/types"
+import { MESSAGE_TYPE_OPTIONS } from "@/types"
 
 const PAGE_SIZE = 50
 const LOAD_MORE_THRESHOLD = 120
@@ -234,6 +242,7 @@ export function TaskMessagesTab({ taskId }: TaskMessagesTabProps) {
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [hasMore, setHasMore] = useState(true)
+  const [messageTypeFilter, setMessageTypeFilter] = useState<MessageType | 'all'>('all')
 
   const loadMessages = useCallback(async (offset: number, reset: boolean) => {
     if (reset) {
@@ -244,7 +253,12 @@ export function TaskMessagesTab({ taskId }: TaskMessagesTabProps) {
     }
 
     try {
-      const nextMessages = await getTaskMessages(taskId, PAGE_SIZE, offset)
+      const nextMessages = await getTaskMessages(
+        taskId,
+        PAGE_SIZE,
+        offset,
+        messageTypeFilter
+      )
 
       setMessages((current) => (reset ? nextMessages : [...current, ...nextMessages]))
       setHasMore(nextMessages.length === PAGE_SIZE)
@@ -254,14 +268,14 @@ export function TaskMessagesTab({ taskId }: TaskMessagesTabProps) {
       setLoading(false)
       setLoadingMore(false)
     }
-  }, [taskId])
+  }, [taskId, messageTypeFilter])
 
   useEffect(() => {
     setMessages([])
     setHasMore(true)
     setError(null)
     void loadMessages(0, true)
-  }, [loadMessages, taskId])
+  }, [loadMessages, taskId, messageTypeFilter])
 
   const handleScroll = useCallback((event: UIEvent<HTMLDivElement>) => {
     const target = event.currentTarget
@@ -347,16 +361,33 @@ export function TaskMessagesTab({ taskId }: TaskMessagesTabProps) {
             </div>
           </div>
 
-          <Button
-            variant="outline"
-            size="sm"
-            className="rounded-full"
-            onClick={() => void loadMessages(0, true)}
-            disabled={loading || loadingMore}
-          >
-            <RefreshCw className={`mr-1.5 size-3.5 ${loading ? "animate-spin" : ""}`} />
-            刷新
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <Select
+              value={messageTypeFilter}
+              onValueChange={(value) => setMessageTypeFilter(value as MessageType | 'all')}
+            >
+              <SelectTrigger className="h-8 w-[160px] rounded-full text-xs">
+                <SelectValue placeholder="消息类型" />
+              </SelectTrigger>
+              <SelectContent>
+                {MESSAGE_TYPE_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              variant="outline"
+              size="sm"
+              className="rounded-full"
+              onClick={() => void loadMessages(0, true)}
+              disabled={loading || loadingMore}
+            >
+              <RefreshCw className={`mr-1.5 size-3.5 ${loading ? "animate-spin" : ""}`} />
+              刷新
+            </Button>
+          </div>
         </div>
 
         {error && messages.length > 0 ? (

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -212,3 +212,23 @@ export const STATUS_LABELS: Record<TaskStatus | 'all', string> = {
 };
 
 export type LogEntry = string;
+
+export type LogLevel = 'ERROR' | 'WARN' | 'INFO' | 'DEBUG';
+
+export const MESSAGE_TYPE_OPTIONS: { value: MessageType | 'all'; label: string }[] = [
+  { value: 'all', label: '全部' },
+  { value: 'user_prompt', label: '用户输入' },
+  { value: 'user_steering', label: 'Steer 消息' },
+  { value: 'assistant_response', label: '助手回复' },
+  { value: 'assistant_tool_calls', label: '工具调用' },
+  { value: 'assistant_thinking', label: '思考过程' },
+  { value: 'tool_result', label: '工具结果' },
+];
+
+export const LOG_LEVEL_OPTIONS: { value: LogLevel | 'all'; label: string }[] = [
+  { value: 'all', label: '全部' },
+  { value: 'ERROR', label: 'ERROR' },
+  { value: 'WARN', label: 'WARN' },
+  { value: 'INFO', label: 'INFO' },
+  { value: 'DEBUG', label: 'DEBUG' },
+];


### PR DESCRIPTION
## Summary
- add task message filtering by message_type in the backend API and web UI
- add task log filtering by level in the backend API and web UI
- reset paginated message/log lists when filters change in the task detail modal
- fix log level matching so message-body text like error sending request in a WARN line is not misclassified as ERROR

## Verification
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- 
pm run build
- real API comparison using existing task data for message_type and level filters