### PR TITLE
refactor(tool): extract shared SQL SELECT validation

### DIFF
--- a/src/tool/query_messages.rs
+++ b/src/tool/query_messages.rs
@@ -11,6 +11,16 @@ use crate::{
 
 const MAX_ROWS: usize = 100;
 
+pub(crate) fn validate_select_query(sql: &str) -> BabataResult<()> {
+    let trimmed = sql.trim().to_uppercase();
+    if !trimmed.starts_with("SELECT") {
+        return Err(crate::error::BabataError::tool(
+            "Only SELECT queries are allowed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub fn process_query_results_with_truncation<T: serde::Serialize>(
     results: &[T],
     context: &ToolContext<'_>,
@@ -89,13 +99,7 @@ impl Tool for QueryMessagesTool {
     async fn execute(&self, args: &str, context: &ToolContext<'_>) -> BabataResult<String> {
         let QueryMessagesArgs { agent, sql } = parse_tool_args(args)?;
 
-        // Basic validation to ensure it's a SELECT query
-        let trimmed = sql.trim().to_uppercase();
-        if !trimmed.starts_with("SELECT") {
-            return Err(crate::error::BabataError::tool(
-                "Only SELECT queries are allowed".to_string(),
-            ));
-        }
+        validate_select_query(&sql)?;
 
         let agent_home = agent_dir(&agent)?;
         let store = MessageStore::new(&agent_home)?;

--- a/src/tool/query_tasks.rs
+++ b/src/tool/query_tasks.rs
@@ -39,13 +39,7 @@ impl Tool for QueryTasksTool {
     async fn execute(&self, args: &str, context: &ToolContext<'_>) -> BabataResult<String> {
         let QueryTasksArgs { sql } = parse_tool_args(args)?;
 
-        // Basic validation to ensure it's a SELECT query
-        let trimmed = sql.trim().to_uppercase();
-        if !trimmed.starts_with("SELECT") {
-            return Err(crate::error::BabataError::tool(
-                "Only SELECT queries are allowed".to_string(),
-            ));
-        }
+        crate::tool::query_messages::validate_select_query(&sql)?;
 
         let results = self.task_store.query_sql(&sql)?;
         crate::tool::query_messages::process_query_results_with_truncation(


### PR DESCRIPTION
Extract duplicated SQL SELECT validation logic from query_messages and query_tasks into a shared alidate_select_query helper in query_messages.rs.

- Removes 14 lines of duplicated code across two files
- No behavior change; validation logic remains identical
- Both tools already shared process_query_results_with_truncation from the same module, so this follows the existing pattern