### PR TITLE
refactor(http): extract require_non_empty helper to reduce duplication

### DIFF
--- a/src/http/agents.rs
+++ b/src/http/agents.rs
@@ -19,6 +19,7 @@ use crate::{
 use super::{
     HttpApp,
     file_browser::{BrowsedPath, FileEntry, browse_path, build_file_request},
+    require_non_empty,
 };
 
 pub(super) async fn list() -> BabataResult<Json<ListAgentsResponse>> {
@@ -50,9 +51,7 @@ pub(super) async fn create(
     State(_state): State<HttpApp>,
     Json(request): Json<CreateAgentRequest>,
 ) -> BabataResult<()> {
-    if request.name.trim().is_empty() {
-        return Err(BabataError::invalid_input("name cannot be empty"));
-    }
+    require_non_empty(&request.name, "name")?;
 
     validate_provider_model_selection(&request.provider, &request.model)?;
 

--- a/src/http/collaborate_task.rs
+++ b/src/http/collaborate_task.rs
@@ -6,21 +6,17 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{BabataResult, error::BabataError, task::CollaborationTaskState};
+use crate::{BabataResult, task::CollaborationTaskState};
 
-use super::HttpApp;
+use super::{HttpApp, require_non_empty};
 
 pub(super) async fn create(
     State(state): State<HttpApp>,
     Path(task_id): Path<Uuid>,
     Json(request): Json<CollaborateTaskRequest>,
 ) -> BabataResult<()> {
-    if request.agent.trim().is_empty() {
-        return Err(BabataError::invalid_input("agent cannot be empty"));
-    }
-    if request.prompt.trim().is_empty() {
-        return Err(BabataError::invalid_input("prompt cannot be empty"));
-    }
+    require_non_empty(&request.agent, "agent")?;
+    require_non_empty(&request.prompt, "prompt")?;
 
     state.task_manager.collaborate_task(task_id, request)?;
     Ok(())

--- a/src/http/create_task.rs
+++ b/src/http/create_task.rs
@@ -8,7 +8,7 @@ use crate::{
     task::{CreateTaskRequest, TaskStatus},
 };
 
-use super::HttpApp;
+use super::{HttpApp, require_non_empty};
 
 pub(super) async fn handle(
     State(state): State<HttpApp>,
@@ -17,12 +17,8 @@ pub(super) async fn handle(
     if request.prompt.is_empty() {
         return Err(BabataError::invalid_input("prompt cannot be empty"));
     }
-    if request.description.trim().is_empty() {
-        return Err(BabataError::invalid_input("description cannot be empty"));
-    }
-    if request.agent.trim().is_empty() {
-        return Err(BabataError::invalid_input("agent cannot be empty"));
-    }
+    require_non_empty(&request.description, "description")?;
+    require_non_empty(&request.agent, "agent")?;
 
     let task_id = state.task_manager.create_task(request)?;
     Ok(Json(CreateTaskResponse {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -204,6 +204,16 @@ pub(crate) fn ensure_task_exists(task_manager: &TaskManager, task_id: Uuid) -> B
     Ok(())
 }
 
+/// Validate that a string field is not empty or whitespace-only.
+pub(crate) fn require_non_empty(field: &str, name: &str) -> BabataResult<()> {
+    if field.trim().is_empty() {
+        return Err(BabataError::invalid_input(format!(
+            "{name} cannot be empty"
+        )));
+    }
+    Ok(())
+}
+
 fn parse_http_addr(raw: &str) -> BabataResult<SocketAddr> {
     raw.parse::<SocketAddr>().map_err(|err| {
         BabataError::config(format!(

--- a/src/http/relaunch_task.rs
+++ b/src/http/relaunch_task.rs
@@ -5,9 +5,9 @@ use axum::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{BabataResult, error::BabataError};
+use crate::BabataResult;
 
-use super::{HttpApp, parse_task_id};
+use super::{HttpApp, parse_task_id, require_non_empty};
 
 pub(super) async fn handle(
     State(state): State<HttpApp>,
@@ -15,12 +15,11 @@ pub(super) async fn handle(
     Json(request): Json<RelaunchTaskRequest>,
 ) -> BabataResult<()> {
     let task_id = parse_task_id(&task_id)?;
-    let reason = request.reason.trim();
-    if reason.is_empty() {
-        return Err(BabataError::invalid_input("reason cannot be empty"));
-    }
+    require_non_empty(&request.reason, "reason")?;
 
-    state.task_manager.relaunch_task(task_id, reason)?;
+    state
+        .task_manager
+        .relaunch_task(task_id, request.reason.trim())?;
     Ok(())
 }
 


### PR DESCRIPTION
提取 equire_non_empty 辅助函数，减少 4 个 HTTP handler 中 6 处重复空值检查；行为不变。