### PR TITLE
fix(http): task log level filter matches logforth default format

### DIFF
--- a/src/http/get_task_logs.rs
+++ b/src/http/get_task_logs.rs
@@ -40,13 +40,21 @@ impl std::str::FromStr for LogLevel {
 impl LogLevel {
     fn matches(&self, log: &str) -> bool {
         let upper_log = log.to_ascii_uppercase();
-        // Log lines typically look like: "2024-01-01 12:00:00 [INFO] [task-id] message"
-        // We check for the level enclosed in brackets [LEVEL] to avoid false positives in the message body.
+        // Log lines typically look like one of:
+        //   "2024-01-01 12:00:00 [INFO] [task-id] message"   (bracket format)
+        //   "2024-01-01T12:00:00   INFO module:file:line [task-id] message" (logforth default)
+        // We check both the bracket form and the second whitespace-delimited token
+        // to avoid false positives in the message body.
+        let second_token = upper_log.split_whitespace().nth(1);
         match self {
-            LogLevel::Error => upper_log.contains("[ERROR]"),
-            LogLevel::Warn => upper_log.contains("[WARN]") || upper_log.contains("[WARNING]"),
-            LogLevel::Info => upper_log.contains("[INFO]"),
-            LogLevel::Debug => upper_log.contains("[DEBUG]"),
+            LogLevel::Error => upper_log.contains("[ERROR]") || second_token == Some("ERROR"),
+            LogLevel::Warn => {
+                upper_log.contains("[WARN]")
+                    || upper_log.contains("[WARNING]")
+                    || second_token == Some("WARN")
+            }
+            LogLevel::Info => upper_log.contains("[INFO]") || second_token == Some("INFO"),
+            LogLevel::Debug => upper_log.contains("[DEBUG]") || second_token == Some("DEBUG"),
         }
     }
 }
@@ -227,7 +235,7 @@ mod tests {
     }
 
     #[test]
-    fn log_level_matches_correctly() {
+    fn log_level_matches_bracket_format() {
         assert!(LogLevel::Error.matches("2024-01-01 [task-id] [ERROR] something failed"));
         assert!(!LogLevel::Error.matches("2024-01-01 [task-id] [INFO] ERROR in request body"));
         assert!(!LogLevel::Error.matches("2024-01-01 [task-id] [WARN] error sending request"));
@@ -242,5 +250,38 @@ mod tests {
 
         assert!(LogLevel::Debug.matches("2024-01-01 [task-id] [DEBUG] trace"));
         assert!(!LogLevel::Debug.matches("2024-01-01 [task-id] [INFO] normal"));
+    }
+
+    #[test]
+    fn log_level_matches_logforth_default_format() {
+        // logforth TextLayout default: "2026-04-28T00:00:07.638041+08:00   INFO module:file:line [task-id] message"
+        let info_line = "2026-04-28T00:00:07.638041+08:00   INFO babata::agent::runner: runner.rs:96 [task-id] Provider returned message";
+        let warn_line = "2026-04-28T00:00:07.638041+08:00   WARN babata::http: get_task_logs.rs:42 [task-id] caution";
+        let error_line = "2026-04-28T00:00:07.638041+08:00   ERROR babata::task: manager.rs:15 [task-id] something failed";
+        let debug_line =
+            "2026-04-28T00:00:07.638041+08:00   DEBUG babata::tool: shell.rs:8 [task-id] trace";
+
+        assert!(LogLevel::Info.matches(info_line));
+        assert!(!LogLevel::Error.matches(info_line));
+        assert!(!LogLevel::Warn.matches(info_line));
+        assert!(!LogLevel::Debug.matches(info_line));
+
+        assert!(LogLevel::Warn.matches(warn_line));
+        assert!(!LogLevel::Error.matches(warn_line));
+        assert!(!LogLevel::Info.matches(warn_line));
+
+        assert!(LogLevel::Error.matches(error_line));
+        assert!(!LogLevel::Info.matches(error_line));
+
+        assert!(LogLevel::Debug.matches(debug_line));
+        assert!(!LogLevel::Info.matches(debug_line));
+    }
+
+    #[test]
+    fn log_level_does_not_match_level_in_message_body_for_logforth_format() {
+        // The word "ERROR" appears in the message body, but the actual level is INFO.
+        let line = "2026-04-28T00:00:07.638041+08:00   INFO babata::agent::runner: runner.rs:96 [task-id] ERROR in request body";
+        assert!(!LogLevel::Error.matches(line));
+        assert!(LogLevel::Info.matches(line));
     }
 }


### PR DESCRIPTION
## Problem

The task log level filter in the Web UI always returned empty results when any level (ERROR/WARN/INFO/DEBUG) was selected.

## Root Cause

LogLevel::matches only checked for bracket-wrapped levels like [INFO], but logforth's TextLayout default outputs levels **without brackets**:

`
2026-04-28T00:00:07.638041+08:00   INFO babata::agent::runner: runner.rs:96 [task-id] message
`

Because [INFO] never appeared in actual log lines, the backend filter dropped every line, so the frontend showed an empty list.

## Fix

Also match the second whitespace-delimited token, which is the level in logforth's default output format. Keep bracket matching for backward compatibility.

## Verification

- Added unit tests covering logforth default format (log_level_matches_logforth_default_format)
- Added regression test ensuring message-body level words are not matched (log_level_does_not_match_level_in_message_body_for_logforth_format)
- All existing tests continue to pass (cargo test 201 passed)
- cargo fmt and cargo clippy --all-targets --all-features -- -D warnings pass