### PR TITLE
refactor: extract shared SKIP_DIRS constant to utils

### DIFF
--- a/src/http/file_browser.rs
+++ b/src/http/file_browser.rs
@@ -3,22 +3,7 @@ use std::path::Path;
 use axum::{body::Body, extract::Request, http::Uri};
 use serde::Serialize;
 
-use crate::{BabataResult, error::BabataError};
-
-// Directories to skip when listing files (same as grep tool)
-const SKIP_DIRS: &[&str] = &[
-    ".git",
-    "node_modules",
-    "__pycache__",
-    ".venv",
-    "venv",
-    ".tox",
-    "dist",
-    "build",
-    "target",
-    ".idea",
-    ".vscode",
-];
+use crate::{BabataResult, error::BabataError, utils::SKIP_DIRS};
 
 /// File or directory entry
 #[derive(Debug, Serialize)]

--- a/src/tool/grep.rs
+++ b/src/tool/grep.rs
@@ -10,22 +10,9 @@ use crate::{
     BabataResult,
     error::BabataError,
     tool::{Tool, ToolContext, ToolSpec, parse_tool_args, resolve_tool_path},
+    utils::SKIP_DIRS,
 };
 
-// skip these dirs to avoid noise
-const SKIP_DIRS: &[&str] = &[
-    ".git",
-    "node_modules",
-    "__pycache__",
-    ".venv",
-    "venv",
-    ".tox",
-    "dist",
-    "build",
-    "target",
-    ".idea",
-    ".vscode",
-];
 const MAX_MATCHES: usize = 200;
 const MAX_FILES: usize = 5000;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,3 +51,19 @@ pub const fn build_commit() -> Option<&'static str> {
         _ => None,
     }
 }
+
+/// Directories to skip when scanning or listing files (e.g., build artifacts,
+/// dependency caches, IDE metadata).
+pub const SKIP_DIRS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".tox",
+    "dist",
+    "build",
+    "target",
+    ".idea",
+    ".vscode",
+];


### PR DESCRIPTION
## Summary

Both src/http/file_browser.rs and src/tool/grep.rs maintained identical local SKIP_DIRS constants. Extract it to src/utils.rs to eliminate duplication and make future updates (e.g., adding new IDE/build directories) a single-point change.

## Changes

- **Added** pub const SKIP_DIRS to src/utils.rs
- **Removed** local SKIP_DIRS from src/http/file_browser.rs
- **Removed** local SKIP_DIRS from src/tool/grep.rs
- Both modules now import crate::utils::SKIP_DIRS

## Verification

- cargo test -- --skip log_level_matches_correctly: 198 passed, 0 failed (the skipped test is a pre-existing failure on main unrelated to this change)
- cargo test file_browser: 7 passed, 0 failed
- cargo test grep: 7 passed, 0 failed
- cargo fmt: clean
- cargo clippy --all-targets --all-features -- -D warnings: clean

## Risk

Zero. This is a pure compile-time constant move with no behavioral change.