### PR TITLE
fix(web): eliminate setState-in-effect ESLint violations

### DIFF
--- a/web/src/components/DeleteConfirmModal.tsx
+++ b/web/src/components/DeleteConfirmModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { AlertTriangle, LoaderCircle } from "lucide-react"
 
 import {
@@ -31,12 +31,6 @@ export function DeleteConfirmModal({
 }: DeleteConfirmModalProps) {
   const [isDeleting, setIsDeleting] = useState(false)
 
-  useEffect(() => {
-    if (isOpen) {
-      setIsDeleting(false)
-    }
-  }, [isOpen, taskId])
-
   const handleConfirm = async () => {
     setIsDeleting(true)
     try {
@@ -47,7 +41,15 @@ export function DeleteConfirmModal({
   }
 
   return (
-    <AlertDialog open={isOpen} onOpenChange={(open) => (!open ? onCancel() : undefined)}>
+    <AlertDialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          setIsDeleting(false)
+          onCancel()
+        }
+      }}
+    >
       <AlertDialogContent className="rounded-[1.75rem] border-border/70 bg-card/95 shadow-[0_24px_90px_-40px_rgba(15,23,42,0.48)] backdrop-blur-2xl">
         <AlertDialogHeader className="space-y-4">
           <div className="flex items-center gap-3">

--- a/web/src/pages/Providers/Providers.tsx
+++ b/web/src/pages/Providers/Providers.tsx
@@ -473,16 +473,9 @@ function ProviderConnectionTestDialog({
   onTest: (provider: ProviderConfig, model: string) => Promise<{ latencyMs: number }>
 }) {
   const [testLoading, setTestLoading] = useState(false)
-  const [testModel, setTestModel] = useState("")
+  const [testModel, setTestModel] = useState(provider?.models[0]?.id ?? "")
   const [testResult, setTestResult] = useState<string | null>(null)
   const [testError, setTestError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!open || !provider) return
-    setTestModel(provider.models[0]?.id ?? "")
-    setTestResult(null)
-    setTestError(null)
-  }, [open, provider])
 
   if (!provider) return null
 
@@ -792,6 +785,7 @@ export function Providers() {
       />
 
       <ProviderConnectionTestDialog
+        key={testModalOpen ? selectedProvider?.name ?? "test" : "closed"}
         provider={selectedProvider}
         open={testModalOpen}
         onOpenChange={setTestModalOpen}

--- a/web/src/pages/Tasks/Tasks.tsx
+++ b/web/src/pages/Tasks/Tasks.tsx
@@ -384,6 +384,7 @@ export function Tasks() {
       />
 
       <DeleteConfirmModal
+        key={taskToDelete?.task_id ?? "delete-modal"}
         isOpen={showDeleteModal}
         taskId={taskToDelete?.task_id ?? ""}
         taskDescription={taskToDelete?.description ?? ""}


### PR DESCRIPTION
Two React components were calling setState directly inside useEffect, triggering the react-hooks/set-state-in-effect ESLint rule. This pattern can cause cascading renders and is discouraged by React.

DeleteConfirmModal:
- Removed useEffect that reset isDeleting when isOpen became true.
- Reset isDeleting in the onOpenChange close handler instead.
- Added key={taskId} at the call site so the component remounts when the target task changes, giving a clean initial state.

ProviderConnectionTestDialog:
- Removed useEffect that reset test form state when open became true.
- Derived initial testModel from props via useState initializer.
- Added key based on open state at the call site so the component remounts each time the dialog is opened, preserving the reset behavior without an effect.

Verification:
- npm run lint: passes (0 errors, 0 warnings)
- npm run build: passes
- cargo fmt: passes
- cargo clippy --all-targets --all-features -- -D warnings: passes
- cargo test: 208 passed, 0 failed